### PR TITLE
Don't crash on m.image without url

### DIFF
--- a/src/domain/session/room/timeline/tiles/ImageTile.js
+++ b/src/domain/session/room/timeline/tiles/ImageTile.js
@@ -27,12 +27,18 @@ export class ImageTile extends MessageTile {
 
     get thumbnailUrl() {
         const mxcUrl = this._getContent().url;
-        return this._room.mxcUrlThumbnail(mxcUrl, this.thumbnailWidth, this.thumbnailHeight, "scale");
+        if (mxcUrl) {
+            return this._room.mxcUrlThumbnail(mxcUrl, this.thumbnailWidth, this.thumbnailHeight, "scale");
+        }
+        return null;
     }
 
     get url() {
         const mxcUrl = this._getContent().url;
-        return this._room.mxcUrl(mxcUrl);   
+        if (mxcUrl) {
+            return this._room.mxcUrl(mxcUrl);
+        }
+        return null;
     }
 
     _scaleFactor() {


### PR DESCRIPTION
A fix because https://github.com/vector-im/element-meta/issues/1390 happened