### PR TITLE
Store session values as separate entries in store

### DIFF
--- a/src/matrix/room/RoomSummary.js
+++ b/src/matrix/room/RoomSummary.js
@@ -263,7 +263,7 @@ export function tests() {
         "membership trigger change": function(assert) {
             const summary = new RoomSummary("id");
             let written = false;
-            const changes = summary.writeSync({}, "join", {roomSummary: {set: () => { written = true; }}});
+            const changes = summary.writeSync({}, "join", false, false, {roomSummary: {set: () => { written = true; }}});
             assert(changes);
             assert(written);
             assert.equal(changes.membership, "join");

--- a/src/matrix/storage/idb/schema.js
+++ b/src/matrix/storage/idb/schema.js
@@ -54,10 +54,10 @@ async function migrateSession(db, txn) {
         const entry = await reqAsPromise(session.get(PRE_MIGRATION_KEY));
         if (entry) {
             session.delete(PRE_MIGRATION_KEY);
+            const {syncToken, syncFilterId, serverVersions} = entry.value;
             const store = new SessionStore(session);
-            for (const [key, value] of Object.entries(entry.value)) {
-                store.set(key, value);
-            }
+            store.set("sync", {token: syncToken, filterId: syncFilterId});
+            store.set("serverVersions", serverVersions);
         }
     } catch (err) {
         txn.abort();

--- a/src/matrix/storage/idb/schema.js
+++ b/src/matrix/storage/idb/schema.js
@@ -1,12 +1,14 @@
-import {iterateCursor} from "./utils.js";
+import {iterateCursor, reqAsPromise} from "./utils.js";
 import {RoomMember, EVENT_TYPE as MEMBER_EVENT_TYPE} from "../../room/members/RoomMember.js";
 import {RoomMemberStore} from "./stores/RoomMemberStore.js";
+import {SessionStore} from "./stores/SessionStore.js";
 
 // FUNCTIONS SHOULD ONLY BE APPENDED!!
 // the index in the array is the database version
 export const schema = [
     createInitialStores,
     createMemberStore,
+    migrateSession,
 ];
 // TODO: how to deal with git merge conflicts of this array?
 
@@ -43,4 +45,22 @@ async function createMemberStore(db, txn) {
             }
         }
     });
+}
+
+async function migrateSession(db, txn) {
+    const session = txn.objectStore("session");
+    try {
+        const PRE_MIGRATION_KEY = 1;
+        const entry = await reqAsPromise(session.get(PRE_MIGRATION_KEY));
+        if (entry) {
+            session.delete(PRE_MIGRATION_KEY);
+            const store = new SessionStore(session);
+            for (const [key, value] of Object.entries(entry.value)) {
+                store.set(key, value);
+            }
+        }
+    } catch (err) {
+        txn.abort();
+        console.error("could not migrate session", err.stack);
+    }
 }

--- a/src/matrix/storage/idb/stores/SessionStore.js
+++ b/src/matrix/storage/idb/stores/SessionStore.js
@@ -35,14 +35,14 @@ export class SessionStore {
 		this._sessionStore = sessionStore;
 	}
 
-	async get() {
-		const session = await this._sessionStore.selectFirst(IDBKeyRange.only(1));
-		if (session) {
-			return session.value;
+	async get(key) {
+		const entry = await this._sessionStore.get(key);
+		if (entry) {
+			return entry.value;
 		}
 	}
 
-	set(session) {
-		return this._sessionStore.put({key: 1, value: session});
+	set(key, value) {
+		return this._sessionStore.put({key, value});
 	}
 }


### PR DESCRIPTION
So we don't have to write everything when changing one value.

We'll store everything that has the scope of an account in here, like the olm account, the own display name and avatar, ... things with varying update times.