### PR TITLE
Fix race between next /sync and upload OTKs

### DIFF
--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -384,7 +384,7 @@ export class Session {
             // sync transaction succeeded, modify object state now
             this._syncInfo = syncInfo;
         }
-        if (this._e2eeAccount && e2eeAccountChanges) {
+        if (this._e2eeAccount) {
             this._e2eeAccount.afterSync(e2eeAccountChanges);
         }
     }

--- a/src/matrix/Sync.js
+++ b/src/matrix/Sync.js
@@ -98,11 +98,27 @@ export class Sync {
             let roomStates;
             try {
                 console.log(`starting sync request with since ${syncToken} ...`);
-                const timeout = syncToken ? INCREMENTAL_TIMEOUT : undefined; 
+                // unless we are happily syncing already, we want the server to return
+                // as quickly as possible, even if there are no events queued. This
+                // serves two purposes:
+                //
+                // * When the connection dies, we want to know asap when it comes back,
+                //   so that we can hide the error from the user. (We don't want to
+                //   have to wait for an event or a timeout).
+                //
+                // * We want to know if the server has any to_device messages queued up
+                //   for us. We do that by calling it with a zero timeout until it
+                //   doesn't give us any more to_device messages.
+                const timeout = this._status.get() === SyncStatus.Syncing ? INCREMENTAL_TIMEOUT : 0; 
                 const syncResult = await this._syncRequest(syncToken, timeout);
                 syncToken = syncResult.syncToken;
                 roomStates = syncResult.roomStates;
-                this._status.set(SyncStatus.Syncing);
+                // initial sync or catchup sync
+                if (this._status.get() !== SyncStatus.Syncing && syncResult.hadToDeviceMessages) {
+                    this._status.set(SyncStatus.CatchupSync);
+                } else {
+                    this._status.set(SyncStatus.Syncing);
+                }
             } catch (err) {
                 if (!(err instanceof AbortError)) {
                     console.warn("stopping sync because of error");
@@ -118,9 +134,10 @@ export class Sync {
     }
 
     async _runAfterSyncCompleted(roomStates) {
+        const isCatchupSync = this._status.get() === SyncStatus.CatchupSync;
         const sessionPromise = (async () => {
             try {
-                await this._session.afterSyncCompleted();
+                await this._session.afterSyncCompleted(isCatchupSync);
             } catch (err) {
                 console.error("error during session afterSyncCompleted, continuing",  err.stack);
             }
@@ -186,7 +203,12 @@ export class Sync {
             rs.room.afterSync(rs.changes);
         }
 
-        return {syncToken, roomStates};
+        const toDeviceEvents = response.to_device?.events;
+        return {
+            syncToken,
+            roomStates,
+            hadToDeviceMessages: Array.isArray(toDeviceEvents) && toDeviceEvents.length > 0,
+        };
     }
 
     async _openPrepareSyncTxn() {

--- a/src/matrix/e2ee/Account.js
+++ b/src/matrix/e2ee/Account.js
@@ -171,7 +171,7 @@ export class Account {
 
     writeSync(deviceOneTimeKeysCount, txn) {
         // we only upload signed_curve25519 otks
-        const otkCount = deviceOneTimeKeysCount.signed_curve25519;
+        const otkCount = deviceOneTimeKeysCount.signed_curve25519 || 0;
         if (Number.isSafeInteger(otkCount) && otkCount !== this._serverOTKCount) {
             txn.session.set(SERVER_OTK_COUNT_SESSION_KEY, otkCount);
             return otkCount;


### PR DESCRIPTION
This caused hydrogen to double upload OTKs (a second time based on an old count as the sync request runs in parallel with the previous afterSyncCompleted phase) create more OTKs than it could hold. The OTKs that we forgot about make olm throw BAD_MESSAGE_KEY_ID when creating new inbound olm sessions, losing room keys. Solution is to not run afterSyncCompleted and the next sync in parallel.

This also implements https://github.com/vector-im/element-web/issues/2782 like element does on all platforms.