### PR TITLE
Improve caching and fix working offline

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 	<body class="hydrogen">
         <script id="version" type="disabled">
             window.HYDROGEN_VERSION = "%%VERSION%%";
+            window.HYDROGEN_GLOBAL_HASH = "%%GLOBAL_HASH%%";
         </script>
 		<script id="main" type="module">
 			import {main} from "./src/main.js";

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -45,7 +45,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectDir = path.join(__dirname, "../");
 const cssSrcDir = path.join(projectDir, "src/ui/web/css/");
-const targetDir = path.join(projectDir, "target/");
 
 const program = new commander.Command();
 program
@@ -65,6 +64,7 @@ async function build() {
         themes.push(themeName);
     });
     // clear target dir
+    const targetDir = path.join(projectDir, "target/");
     await removeDirIfExists(targetDir);
     await createDirs(targetDir, themes);
     const assets = new AssetMap(targetDir);
@@ -111,7 +111,7 @@ async function createDirs(targetDir, themes) {
 
 async function copyThemeAssets(themes, assets) {
     for (const theme of themes) {
-        const themeDstFolder = path.join(targetDir, `themes/${theme}`);
+        const themeDstFolder = path.join(assets.directory, `themes/${theme}`);
         const themeSrcFolder = path.join(cssSrcDir, `themes/${theme}`);
         const themeAssets = await copyFolder(themeSrcFolder, themeDstFolder, file => {
             return !file.endsWith(".css");

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -391,7 +391,6 @@ class AssetMap {
         if (!assetMap.directory.startsWith(this.directory)) {
             throw new Error(`map directory doesn't start with this directory: ${assetMap.directory} ${this.directory}`);
         }
-        console.log("adding submap from", assetMap.directory, this.directory);
         const relSubRoot = assetMap.directory.substr(this.directory.length + 1);
         for (const [key, value] of assetMap._assets.entries()) {
             this._assets.set(path.join(relSubRoot, key), path.join(relSubRoot, value));

--- a/scripts/serve-local.js
+++ b/scripts/serve-local.js
@@ -35,6 +35,7 @@ const serve = serveStatic(
  
 // Create server
 const server = http.createServer(function onRequest (req, res) {
+    console.log(req.method, req.url);
 	serve(req, res, finalhandler(req, res))
 });
 

--- a/src/service-worker.template.js
+++ b/src/service-worker.template.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2020 Bruno Windels <bruno@windels.cloud>
+Copyright 2020 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -58,11 +59,11 @@ async function purgeOldCaches() {
 }
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(purgeOldCaches());
+    event.waitUntil(purgeOldCaches());
 });
 
 self.addEventListener('fetch', (event) => {
-  event.respondWith(handleRequest(event.request));
+    event.respondWith(handleRequest(event.request));
 });
 
 async function handleRequest(request) {

--- a/src/service-worker.template.js
+++ b/src/service-worker.template.js
@@ -14,38 +14,90 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const VERSION = "%%VERSION%%";
-const OFFLINE_FILES = "%%OFFLINE_FILES%%";
-// TODO: cache these files when requested
-// The difficulty is that these are relative filenames, and we don't have access to document.baseURI
-// Clients.match({type: "window"}).url and assume they are all the same? they really should be ... safari doesn't support this though
-const CACHE_FILES = "%%CACHE_FILES%%";
-const cacheName = `hydrogen-${VERSION}`;
+const GLOBAL_HASH = "%%GLOBAL_HASH%%";
+const UNHASHED_PRECACHED_ASSETS = "%%UNHASHED_PRECACHED_ASSETS%%";
+const HASHED_PRECACHED_ASSETS = "%%HASHED_PRECACHED_ASSETS%%";
+const HASHED_CACHED_ON_REQUEST_ASSETS = "%%HASHED_CACHED_ON_REQUEST_ASSETS%%";
+const unhashedCacheName = `hydrogen-assets-${GLOBAL_HASH}`;
+const hashedCacheName = `hydrogen-assets`;
 
 self.addEventListener('install', function(e) {
-    e.waitUntil(
-        caches.open(cacheName).then(function(cache) {
-            return cache.addAll(OFFLINE_FILES);
-        })
-    );
+    e.waitUntil((async () => {
+        const unhashedCache = await caches.open(unhashedCacheName);
+        await unhashedCache.addAll(UNHASHED_PRECACHED_ASSETS);
+        const hashedCache = await caches.open(hashedCacheName);
+        await Promise.all(HASHED_PRECACHED_ASSETS.map(async asset => {
+            if (!await hashedCache.match(asset)) {
+                await hashedCache.add(asset);
+            }
+        }));
+    })());
 });
 
-self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches.keys().then((keyList) => {
-      return Promise.all(keyList.map((key) => {
-        if (key !== cacheName) {
-          return caches.delete(key);
+async function purgeOldCaches() {
+    // remove any caches we don't know about
+    const keyList = await caches.keys();
+    for (const key of keyList) {
+        if (key !== unhashedCacheName && key !== hashedCacheName) {
+            await caches.delete(key);
         }
-      }));
-    })
-  );
+    }
+    // remove the cache for any old hashed resource
+    const hashedCache = await caches.open(hashedCacheName);
+    const keys = await hashedCache.keys();
+    const hashedAssetURLs =
+        HASHED_PRECACHED_ASSETS
+        .concat(HASHED_CACHED_ON_REQUEST_ASSETS)
+        .map(a => new URL(a, self.registration.scope).href);
+
+    for (const request of keys) {
+        if (!hashedAssetURLs.some(url => url === request.url)) {
+            hashedCache.delete(request);
+        }
+    }
+}
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(purgeOldCaches());
 });
 
 self.addEventListener('fetch', (event) => {
-  event.respondWith(
-    caches.open(cacheName)
-        .then(cache => cache.match(event.request))
-        .then((response) => response || fetch(event.request))
-  );
+  event.respondWith(handleRequest(event.request));
 });
+
+async function handleRequest(request) {
+    const baseURL = self.registration.scope;
+    if (request.url === baseURL) {
+        request = new Request(new URL("index.html", baseURL));
+    }
+    let response = await readCache(request);
+    if (!response) {
+        response = await fetch(request);
+        await updateCache(request, response);
+    }
+    return response;
+}
+
+async function updateCache(request, response) {
+    const baseURL = self.registration.scope;
+    if(!request.url.startsWith(baseURL)) {
+        return;
+    }
+    let assetName = request.url.substr(baseURL.length);
+    if (HASHED_CACHED_ON_REQUEST_ASSETS.includes(assetName)) {
+        const cache = await caches.open(hashedCacheName);
+        await cache.put(request, response.clone());
+    }
+}
+
+async function readCache(request) {
+    const unhashedCache = await caches.open(unhashedCacheName);
+    let response = await unhashedCache.match(request);
+    if (response) {
+        return response;
+    }
+    const hashedCache = await caches.open(hashedCacheName);
+    response = await hashedCache.match(request);
+    return response;
+}
+

--- a/src/ui/web/login/common.js
+++ b/src/ui/web/login/common.js
@@ -18,7 +18,7 @@ export function hydrogenGithubLink(t) {
     if (window.HYDROGEN_VERSION) {
         return t.a({target: "_blank",
             href: `https://github.com/vector-im/hydrogen-web/releases/tag/v${window.HYDROGEN_VERSION}`},
-            `Hydrogen v${window.HYDROGEN_VERSION} on Github`);
+            `Hydrogen v${window.HYDROGEN_VERSION} (${window.HYDROGEN_GLOBAL_HASH}) on Github`);
     } else {
         return t.a({target: "_blank", href: "https://github.com/vector-im/hydrogen-web"},
             "Hydrogen on Github");


### PR DESCRIPTION
 - [x] cache all files (e.g. olm) needed to work offline (fixes #94, make sure it also fixes https://github.com/vector-im/hydrogen-web/issues/41)
 - [x] don't pre-cache everything, some resources are mutually exclusive (and heavy) like woff vs woff2 files. Instead, cache them when requested in the service worker by their filename only (not app version, so we don't have to re-download them with every update). Also remove previous files by iterating over all cache keys and see if there is one the same but with a different hash. 
 - [x] cache unhashed files (index.html) by git commit hash in the service worker, rather than version
 - [x] cache thumbnails below a given size (px, kb) from the homeserver media repository