### PR TITLE
Dark Mode

### DIFF
--- a/src/ui/web/css/themes/element/theme.css
+++ b/src/ui/web/css/themes/element/theme.css
@@ -635,15 +635,19 @@ button.link {
 
 @media (prefers-color-scheme: dark) {
     .hydrogen {
-        background-color: #000;
+        background-color: #15191e;
         color: #fff;
     }
-    .AnnouncementView > div,
+    .AnnouncementView > div {
+        background-color: #20262b;
+    }
     .middle-header,
-    .LeftPanel,
     .RoomHeader {
         background-color: #15191e;
         color: #fff;
+    }
+    .LeftPanel {
+        background-color: #20262b;
     }
     .middle-header,
     .MessageComposer {
@@ -656,7 +660,7 @@ button.link {
     .FilterField:focus-within,
     .button-utility,
     .MessageComposer > button.send:disabled {
-        background-color: #3f3f3f;
+        background-color: #363c43;
         color: #fff;
     }
     .FilterField:focus-within,
@@ -666,5 +670,13 @@ button.link {
     .TimelinePanel .Timeline,
     .LeftPanel .RoomList {
         scrollbar-color: #666 #333;
+    }
+    .form-row input {
+        background-color: #20262b;
+        color: #fff;
+    }
+    .RoomGridView > div.container {
+      	border-right: 1px solid #20262b;
+       	border-bottom: 1px solid #20262b;
     }
 }

--- a/src/ui/web/css/themes/element/theme.css
+++ b/src/ui/web/css/themes/element/theme.css
@@ -627,3 +627,44 @@ button.link {
     color: #03B381;
     font-weight: 600;
 }
+
+.TimelinePanel .Timeline,
+.LeftPanel .RoomList {
+    scrollbar-width: thin;
+}
+
+@media (prefers-color-scheme: dark) {
+    .hydrogen {
+        background-color: #000;
+        color: #fff;
+    }
+    .AnnouncementView > div,
+    .middle-header,
+    .LeftPanel,
+    .RoomHeader {
+        background-color: #15191e;
+        color: #fff;
+    }
+    .middle-header,
+    .MessageComposer {
+        border-color: #15191e;
+    }
+    .MessageComposer > input,
+    .FilterField,
+    .FilterField input,
+    .FilterField button,
+    .FilterField:focus-within,
+    .button-utility,
+    .MessageComposer > button.send:disabled {
+        background-color: #3f3f3f;
+        color: #fff;
+    }
+    .FilterField:focus-within,
+    .FilterField:focus-within button {
+        border-color: transparent;
+    }
+    .TimelinePanel .Timeline,
+    .LeftPanel .RoomList {
+        scrollbar-color: #666 #333;
+    }
+}


### PR DESCRIPTION
This adds a dark mode to Hydrogen. It overrides all the light colors set in `theme.css` with darker ones on `prefers-color-scheme: dark`, so it should only be seen as a hacky first step.

![Screenshot from 2020-10-20 17-30-24](https://user-images.githubusercontent.com/476060/96610358-d421ac80-12fb-11eb-9560-a064949e9a26.png)

This also turns scrollbars of the room list and the timeline dark, but [only in Firefox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scrollbars).