### PR TITLE
Use submit event for login instead of click

### DIFF
--- a/src/platform/web/ui/general/html.js
+++ b/src/platform/web/ui/general/html.js
@@ -94,7 +94,7 @@ export const TAG_NAMES = {
     [HTML_NS]: [
         "br", "a", "ol", "ul", "li", "div", "h1", "h2", "h3", "h4", "h5", "h6",
         "p", "strong", "em", "span", "img", "section", "main", "article", "aside",
-        "pre", "button", "time", "input", "textarea", "label"],
+        "pre", "button", "time", "input", "textarea", "label", "form"],
     [SVG_NS]: ["svg", "circle"]
 };
 

--- a/src/platform/web/ui/login/LoginView.js
+++ b/src/platform/web/ui/login/LoginView.js
@@ -46,20 +46,26 @@ export class LoginView extends TemplateView {
             t.div({className: "LoginView form"}, [
                 t.h1([vm.i18n`Sign In`]),
                 t.if(vm => vm.error, t.createTemplate(t => t.div({className: "error"}, vm => vm.error))),
-                t.div({className: "form-row"}, [t.label({for: "username"}, vm.i18n`Username`), username]),
-                t.div({className: "form-row"}, [t.label({for: "password"}, vm.i18n`Password`), password]),
-                t.div({className: "form-row"}, [t.label({for: "homeserver"}, vm.i18n`Homeserver`), homeserver]),
-                t.mapView(vm => vm.loadViewModel, loadViewModel => loadViewModel ? new SessionLoadStatusView(loadViewModel) : null),
-                t.div({className: "button-row"}, [
-                    t.a({
-                        className: "button-action secondary",
-                        href: vm.cancelUrl
-                    }, [vm.i18n`Go Back`]),
-                    t.button({
-                        className: "button-action primary",
-                        onClick: () => vm.login(username.value, password.value, homeserver.value),
-                        disabled
-                    }, vm.i18n`Log In`),
+                t.form({
+                    onSubmit: evnt => {
+                        evnt.preventDefault();
+                        vm.login(username.value, password.value, homeserver.value);
+                    }
+                }, [
+                    t.div({className: "form-row"}, [t.label({for: "username"}, vm.i18n`Username`), username]),
+                    t.div({className: "form-row"}, [t.label({for: "password"}, vm.i18n`Password`), password]),
+                    t.div({className: "form-row"}, [t.label({for: "homeserver"}, vm.i18n`Homeserver`), homeserver]),
+                    t.mapView(vm => vm.loadViewModel, loadViewModel => loadViewModel ? new SessionLoadStatusView(loadViewModel) : null),
+                    t.div({className: "button-row"}, [
+                        t.a({
+                            className: "button-action secondary",
+                            href: vm.cancelUrl
+                        }, [vm.i18n`Go Back`]),
+                        t.button({
+                            className: "button-action primary",
+                            type: "submit"
+                        }, vm.i18n`Log In`),
+                    ]),
                 ]),
                 // use t.mapView rather than t.if to create a new view when the view model changes too
                 t.p(hydrogenGithubLink(t))


### PR DESCRIPTION
This allows the user to press enter to log in instead of having to click the log in button. It could potentially also allow for other ways of confirming your login if a browser implements others, which may be good for accessibility. Currently a failed login results in the sign in UI going into a frozen state permanently however which is why this is a draft. Rest assured I will continue working on this.