### PR TITLE
Prevent endless loop when hitting server bug at top of timeline

### DIFF
--- a/src/domain/session/room/timeline/TimelineViewModel.js
+++ b/src/domain/session/room/timeline/TimelineViewModel.js
@@ -55,8 +55,8 @@ export class TimelineViewModel extends ViewModel {
         if (firstTile.shape === "gap") {
             return await firstTile.fill();
         } else {
-            await this._timeline.loadAtTop(10);
-            return false;
+            const topReached = await this._timeline.loadAtTop(10);
+            return topReached;
         }
     }
 

--- a/src/matrix/room/Room.js
+++ b/src/matrix/room/Room.js
@@ -441,7 +441,7 @@ export class Room extends EventEmitter {
                     storage: this._storage,
                     fragmentIdComparer: this._fragmentIdComparer,
                 });
-                gapResult = await gapWriter.writeFragmentFill(fragmentEntry, response, txn);
+                gapResult = await gapWriter.writeFragmentFill(fragmentEntry, response, txn, log);
             } catch (err) {
                 txn.abort();
                 throw err;

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -74,13 +74,19 @@ export class Timeline {
     }
     
     // tries to prepend `amount` entries to the `entries` list.
+    /**
+     * [loadAtTop description]
+     * @param  {[type]} amount [description]
+     * @return {boolean} true if the top of the timeline has been reached
+     * 
+     */
     async loadAtTop(amount) {
         if (this._disposables.isDisposed) {
-            return;
+            return true;
         }
         const firstEventEntry = this._remoteEntries.array.find(e => !!e.eventType);
         if (!firstEventEntry) {
-            return;
+            return true;
         }
         const readerRequest = this._disposables.track(this._timelineReader.readFrom(
             firstEventEntry.asEventKey(),
@@ -90,6 +96,7 @@ export class Timeline {
         try {
             const entries = await readerRequest.complete();
             this._remoteEntries.setManySorted(entries);
+            return entries.length < amount;
         } finally {
             this._disposables.disposeTracked(readerRequest);
         }

--- a/src/matrix/room/timeline/persistence/GapWriter.js
+++ b/src/matrix/room/timeline/persistence/GapWriter.js
@@ -235,7 +235,7 @@ export class GapWriter {
             nonOverlappingEvents,
             neighbourFragmentEntry
         } = await this._findOverlappingEvents(fragmentEntry, chunk, txn, log);
-        if (!neighbourFragmentEntry && nonOverlappingEvents.length === 0) {
+        if (!neighbourFragmentEntry && nonOverlappingEvents.length === 0 && typeof end === "string") {
             log.log("hit #160, clearing token", log.level.Warn);
             end = null;
         }


### PR DESCRIPTION
Fixes #160 
It was also tight-looping without the server bug, but the server bug made it worse and corrupted the database. Perhaps these are two separate bugs, but grouping it.