### PR TITLE
New production Dockerfile and GitLab CI definition

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+target

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,61 @@
+image: docker.io/alpine
+
+stages:
+  - test
+  - build
+
+.yarn-template:
+  image: docker.io/node
+  before_script:
+    - yarn install
+  cache:
+    paths:
+      - node_modules
+test:
+  extends: .yarn-template
+  stage: test
+  script:
+    - yarn test
+
+build:
+  extends: .yarn-template
+  stage: build
+  script:
+    - yarn build
+  artifacts:
+    paths:
+      - target
+
+.docker-template:
+  image: docker.io/docker
+  stage: build
+  services:
+    - docker:dind
+  before_script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+
+docker-release:
+  extends: .docker-template
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+  script:
+    - docker build --pull -t "${CI_REGISTRY_IMAGE}:latest" -t "${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG}" .
+    - docker push "${CI_REGISTRY_IMAGE}:latest"
+    - docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG}"
+
+docker-tags:
+  extends: .docker-template
+  rules:
+    - if: '$CI_COMMIT_TAG && $CI_COMMIT_TAG !~ /^v\d+\.\d+\.\d+$/'
+  script:
+    - docker build --pull -t "${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG}" .
+    - docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG}"
+
+docker-branches:
+  extends: .docker-template
+  rules:
+    - if: $CI_COMMIT_BRANCH
+  script:
+    - docker build --pull -t "${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_SLUG}" .
+    - docker push "${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_SLUG}"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM node:alpine3.12
+FROM docker.io/node:alpine as builder
 RUN apk add --no-cache git
-COPY . /code
-WORKDIR /code
-RUN yarn install
-EXPOSE 3000
-ENTRYPOINT ["yarn", "start"]
+COPY . /app
+WORKDIR /app
+RUN yarn install \
+ && yarn build
+
+FROM docker.io/nginx:alpine
+COPY --from=builder /app/target /usr/share/nginx/html

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,7 @@
+FROM docker.io/node:alpine
+RUN apk add --no-cache git
+COPY . /code
+WORKDIR /code
+RUN yarn install
+EXPOSE 3000
+ENTRYPOINT ["yarn", "start"]

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -1,22 +1,58 @@
+## Warning
+
 Usage of docker is a third-party contribution and not actively tested, used or supported by the main developer(s).
 
-Having said that, you can also use Docker to create a local dev environment.
+Having said that, you can also use Docker to create a local dev environment or a production deployment.
+
+## Dev environment
 
 In this repository, create a Docker image:
 
-    docker build -t hydrogen .
+```
+docker build -t hydrogen-dev -f Dockerfile-dev .
+```
 
 Then start up a container from that image:
 
-    docker run \
-        --name hydrogen-dev \
-        --publish 3000:3000 \
-        --volume "$PWD":/code \
-        --interactive \
-        --tty \
-        --rm \
-        hydrogen
+```
+docker run \
+    --name hydrogen-dev \
+    --publish 3000:3000 \
+    --volume "$PWD":/code \
+    --interactive \
+    --tty \
+    --rm \
+    hydrogen-dev
+```
 
 Then point your browser to `http://localhost:3000`. You can see the server logs in the terminal where you started the container.
 
 To stop the container, simply hit `ctrl+c`.
+
+## Production deployment
+
+### Build or pull image
+
+In this repository, create a Docker image:
+
+```
+docker build -t hydrogen .
+```
+
+Or, pull the docker image from GitLab:
+
+```
+docker pull registry.gitlab.com/jcgruenhage/hydrogen-web
+docker tag registry.gitlab.com/jcgruenhage/hydrogen-web hydrogen
+```
+
+### Start container image
+
+Then, start up a container from that image:
+
+```
+docker run \
+    --name hydrogen \
+    --publish 80:80 \
+    hydrogen
+```


### PR DESCRIPTION
The commits have a bit more description of what they do, so take a look at those. The CI definition is tested on gitlab.com already, I've set up a mirror of this repo on gitlab.com/jcgruenhage/hydrogen-web for automated builds in the future. For an example of how this ran for my branch, see https://gitlab.com/jcgruenhage/hydrogen-web/-/pipelines/270179005.

https://gitlab.com/jcgruenhage/hydrogen-web/container_registry/1785520 already has container images available for my branch and v0.1.37, and each new branch and release will get a similar container image, once this PR has been merged. The same is true for webroot dirs, see https://gitlab.com/jcgruenhage/hydrogen-web/-/jobs/1096563366/artifacts/browse/target/ for that.