### PR TITLE
Manually adapt UI when keyboard shows or hides on mobile Safari

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -351,7 +351,11 @@ async function buildCssLegacy(entryPath, urlMapper = null) {
     const preCss = await fs.readFile(entryPath, "utf8");
     const options = [
         postcssImport,
-        cssvariables(),
+        cssvariables({
+            preserve: (declaration) => {
+                return declaration.value.indexOf("var(--ios-") == 0;
+            }
+        }),
         autoprefixer({overrideBrowserslist: ["IE 11"], grid: "no-autoplace"}),
         flexbugsFixes()
     ];

--- a/src/platform/web/dom/download.js
+++ b/src/platform/web/dom/download.js
@@ -14,10 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// From https://stackoverflow.com/questions/9038625/detect-if-device-is-ios/9039885
-const isIOS = /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) && !window.MSStream;
-
-export async function downloadInIframe(container, iframeSrc, blobHandle, filename) {
+export async function downloadInIframe(container, iframeSrc, blobHandle, filename, isIOS) {
     let iframe = container.querySelector("iframe.downloadSandbox");
     if (!iframe) {
         iframe = document.createElement("iframe");

--- a/src/platform/web/ui/css/layout.css
+++ b/src/platform/web/ui/css/layout.css
@@ -54,6 +54,13 @@ main {
     min-width: 0;
 }
 
+/* resize and reposition session view to account for mobile Safari which shifts
+the layout viewport up without resizing it when the keyboard shows */
+.hydrogen.ios .SessionView {
+    height: var(--ios-viewport-height, 100%);
+    top: var(--ios-viewport-top, 0);
+}
+
 /* hide back button in middle section by default */
 .middle .close-middle { display: none; }
 /* mobile layout */

--- a/src/platform/web/ui/session/room/TimelineList.js
+++ b/src/platform/web/ui/session/room/TimelineList.js
@@ -40,7 +40,7 @@ function viewClassForEntry(entry) {
 export class TimelineList extends ListView {
     constructor(viewModel) {
         const options = {
-            className: "Timeline",
+            className: "Timeline bottom-aligned-scroll",
             list: viewModel.tiles,
         }
         super(options, entry => {


### PR DESCRIPTION
Mobile Safari seems to be the only browser that does *not* resize the viewport when the keyboard shows and hides. Instead the window is moved to make room for the keyboard which moves content at the top off screen.

This uses the VisualViewport API to manually resize the `SessionView` in response to keyboard display events. Additionally, the scroll position of the `Timeline` view is retained (if the timeline is currently shown).

Below is a short demo video. This isn't quite perfect but at least it's more usable than before.

https://user-images.githubusercontent.com/1137962/111364120-21c6f900-8691-11eb-8801-f1625f0c3675.MP4

Note that the VisualViewport API was only introduced with iOS 13. According to [statista.com], versions below 13 made up for 19% of all iOS users in summer 2020, with the share continuing to fall off. As a result, this seems like an acceptable workaround.

Things that I wasn't sure about:

1. Is `main.js` the best place for this logic?
2. Should we utilize the user agent to limit this to Safari only? I wasn't able to get Hydrogen to load in mobile Chrome and Firefox so I couldn't test this on other handheld browsers.

Fixes: #181

[statista.com]: https://www.statista.com/statistics/565270/apple-devices-ios-version-share-worldwide/