### PR TITLE
Add previous name in name change announcement

### DIFF
--- a/src/domain/session/room/timeline/tiles/RoomMemberTile.js
+++ b/src/domain/session/room/timeline/tiles/RoomMemberTile.js
@@ -33,7 +33,7 @@ export class RoomMemberTile extends SimpleTile {
             if (content.avatar_url !== prevContent.avatar_url) {
                 return `${senderName} changed their avatar`; 
             } else if (content.displayname !== prevContent.displayname) {
-                return `${senderName} changed their name to ${content.displayname}`; 
+                return `${prevContent.displayname} changed their name to ${content.displayname}`; 
             }
         } else if (membership === "join") {
             return `${targetName} joined the room`;


### PR DESCRIPTION
- Fixes #269 in which the announcement generated when a member
  changes their name would show as :
  <new_name> changed their name to <new_name>
  instead of:
  <old_name> changed their name to <new_name>

Signed-off-by: RMidhunSuresh <rmidhunsuresh@gmail.com>