### PR TITLE
Set explicit height on lightbox container

### DIFF
--- a/src/platform/web/ui/css/layout.css
+++ b/src/platform/web/ui/css/layout.css
@@ -117,6 +117,9 @@ main {
     left: 0;
     right: 0;
     z-index: 1;
+    /* Safari requires an explicit height on the container to prevent picture content from collapsing */
+    box-sizing: border-box;
+    height: 100%;
 }
 
 .TimelinePanel {


### PR DESCRIPTION
Without an explicit height defined on the container, Safari fails to expand the `.picture` content. On desktop this results in the image showing too small and at the top of the screen. On mobile the picture ends up with zero height and is completely hidden.

This commit fixes the issue by defining a height of 100% on the `.lightbox` border box.

**Desktop (before vs. after)**

<img width="521" alt="before-desktop" src="https://user-images.githubusercontent.com/1137962/111995982-dc377f80-8b19-11eb-8d3e-b050eda9cf01.png">

<img width="518" alt="after-desktop" src="https://user-images.githubusercontent.com/1137962/111996023-e48fba80-8b19-11eb-8161-30ea9c6b7d0a.png">

**Mobile (before vs. after)**

<img width="225" alt="before-mobile" src="https://user-images.githubusercontent.com/1137962/111995986-dcd01600-8b19-11eb-8088-cfe0487943b2.png">

<img width="222" alt="after-mobile" src="https://user-images.githubusercontent.com/1137962/111996027-e5285100-8b19-11eb-8532-494581d4b231.png">

Fixes: #278

Signed-off-by: Johannes Marbach <n0-0ne+github@mailbox.org>