### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ If you find this interesting, come and discuss on [`#hydrogen:matrix.org`](https
 Hydrogen is deployed to [hydrogen.element.io](https://hydrogen.element.io). You can run it locally `yarn install` (only the first time) and `yarn start` in the terminal, and point your browser to `http://localhost:3000`. If you prefer, you can also [use docker](doc/docker.md).
 
 Hydrogen uses symbolic links in the codebase, so if you are on Windows, have a look at [making git & symlinks work](https://github.com/git-for-windows/git/wiki/Symbolic-Links) there.
-## For Windows Users
-
-For security reasons, it is better to invoke the command prompt as administrator before running `yarn install`. It is due to the different behavior of [symlinks in windows](https://github.com/git-for-windows/git/wiki/Symbolic-Links).
 
 # FAQ
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If you find this interesting, come and discuss on [`#hydrogen:matrix.org`](https
 
 Hydrogen is deployed to [hydrogen.element.io](https://hydrogen.element.io). You can run it locally `yarn install` (only the first time) and `yarn start` in the terminal, and point your browser to `http://localhost:3000`. If you prefer, you can also [use docker](doc/docker.md).
 
+Hydrogen uses symbolic links in the codebase, so if you are on Windows, have a look at [making git & symlinks work](https://github.com/git-for-windows/git/wiki/Symbolic-Links) there.
 ## For Windows Users
 
 For security reasons, it is better to invoke the command prompt as administrator before running `yarn install`. It is due to the different behavior of [symlinks in windows](https://github.com/git-for-windows/git/wiki/Symbolic-Links).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ If you find this interesting, come and discuss on [`#hydrogen:matrix.org`](https
 
 Hydrogen is deployed to [hydrogen.element.io](https://hydrogen.element.io). You can run it locally `yarn install` (only the first time) and `yarn start` in the terminal, and point your browser to `http://localhost:3000`. If you prefer, you can also [use docker](doc/docker.md).
 
+## For Windows Users
+
+For security reasons, it is better to invoke the command prompt as administrator before running `yarn install`. It is due to the different behavior of [symlinks in windows](https://github.com/git-for-windows/git/wiki/Symbolic-Links).
+
 # FAQ
 
 Some frequently asked questions are answered [here](doc/FAQ.md).


### PR DESCRIPTION
Windows users have to be careful before trying to run locally .Invoking the command prompt as administrator is encouraged. The different behaviour of symlinks in windows is the root cause. Updated the readme file with appropriate instructions.