### PR TITLE
Fix reloading or opening wrong page when clicking notif

### DIFF
--- a/src/platform/web/dom/ServiceWorkerHandler.js
+++ b/src/platform/web/dom/ServiceWorkerHandler.js
@@ -76,6 +76,8 @@ export class ServiceWorkerHandler {
             // this flag is read in fetch.js
             this.haltRequests = true;
             event.source.postMessage({replyTo: data.id});
+        } else if (data.type === "openRoom") {
+            this._navigation.push("room", data.payload.roomId);
         }
     }
 

--- a/src/platform/web/service-worker.js
+++ b/src/platform/web/service-worker.js
@@ -201,9 +201,8 @@ async function openClientFromNotif(event) {
     });
     if (clientWithSession) {
         console.log("notificationclick: client has session open, showing room there");
-        // just change the hash, so the page doesn't refresh on / vs /index.html
-        const roomURL = new URL(roomHash, clientWithSession.url).href;
-        clientWithSession.navigate(roomURL);
+        // use a message rather than clientWithSession.navigate here as this refreshes the page on chrome
+        clientWithSession.postMessage({type: "openRoom", payload: {roomId}});
         if ('focus' in clientWithSession) {
             try {
                 await clientWithSession.focus();

--- a/src/platform/web/service-worker.js
+++ b/src/platform/web/service-worker.js
@@ -196,12 +196,13 @@ async function openClientFromNotif(event) {
     const {sessionId, roomId} = event.notification.data;
     const sessionHash = `#/session/${sessionId}`;
     const roomHash = `${sessionHash}/room/${roomId}`;
-    const roomURL = `/${roomHash}`;
     const clientWithSession = await findClient(async client => {
         return await sendAndWaitForReply(client, "hasSessionOpen", {sessionId});
     });
     if (clientWithSession) {
         console.log("notificationclick: client has session open, showing room there");
+        // just change the hash, so the page doesn't refresh on / vs /index.html
+        const roomURL = new URL(roomHash, clientWithSession.url).href;
         clientWithSession.navigate(roomURL);
         if ('focus' in clientWithSession) {
             try {
@@ -210,6 +211,7 @@ async function openClientFromNotif(event) {
         }
     } else if (self.clients.openWindow) {
         console.log("notificationclick: no client found with session open, opening new window");
+        const roomURL = new URL(`./${roomHash}`, baseURL).href;
         await self.clients.openWindow(roomURL);
     }
 }


### PR DESCRIPTION
previously, it didn't take into account that hydrogen might not be deployed at the root of the origin when opening a new window, and when navigating on an existing client could trigger a reload if the url changed from `/index.html` to `/`.