### PR TITLE
Fix handling connection error during initial sync

### DIFF
--- a/src/matrix/SessionContainer.js
+++ b/src/matrix/SessionContainer.js
@@ -109,7 +109,7 @@ export class SessionContainer {
             let sessionInfo;
             try {
                 const request = this._platform.request;
-                const hsApi = new HomeServerApi({homeServer, request, createTimeout: clock.createTimeout});
+                const hsApi = new HomeServerApi({homeServer, request});
                 const loginData = await hsApi.passwordLogin(username, password, "Hydrogen", {log}).response();
                 const sessionId = this.createNewSessionId();
                 sessionInfo = {
@@ -169,7 +169,6 @@ export class SessionContainer {
             accessToken: sessionInfo.accessToken,
             request: this._platform.request,
             reconnector: this._reconnector,
-            createTimeout: clock.createTimeout
         });
         this._sessionId = sessionInfo.id;
         this._storage = await this._platform.storageFactory.create(sessionInfo.id);

--- a/src/matrix/SessionContainer.js
+++ b/src/matrix/SessionContainer.js
@@ -241,13 +241,13 @@ export class SessionContainer {
                 // keep waiting if there is a ConnectionError
                 // as the reconnector above will call 
                 // sync.start again to retry in this case
-                return this._sync.error.name !== "ConnectionError";
+                return this._sync.error?.name !== "ConnectionError";
             }
             return s === SyncStatus.Syncing;
         });
         try {
             await this._waitForFirstSyncHandle.promise;
-            if (this._sync.status.get() === SyncStatus.Stopped) {
+            if (this._sync.status.get() === SyncStatus.Stopped && this._sync.error) {
                 throw this._sync.error;
             }
         } catch (err) {

--- a/src/matrix/SessionContainer.js
+++ b/src/matrix/SessionContainer.js
@@ -21,7 +21,6 @@ import {Reconnector, ConnectionStatus} from "./net/Reconnector.js";
 import {ExponentialRetryDelay} from "./net/ExponentialRetryDelay.js";
 import {MediaRepository} from "./net/MediaRepository.js";
 import {RequestScheduler} from "./net/RequestScheduler.js";
-import {HomeServerError, ConnectionError, AbortError} from "./error.js";
 import {Sync, SyncStatus} from "./Sync.js";
 import {Session} from "./Session.js";
 
@@ -124,7 +123,7 @@ export class SessionContainer {
                 await this._platform.sessionInfoStorage.add(sessionInfo);            
             } catch (err) {
                 this._error = err;
-                if (err instanceof HomeServerError) {
+                if (err.name === "HomeServerError") {
                     if (err.errcode === "M_FORBIDDEN") {
                         this._loginFailure = LoginFailure.Credentials;
                     } else {
@@ -132,7 +131,7 @@ export class SessionContainer {
                     }
                     log.set("loginFailure", this._loginFailure);
                     this._status.set(LoadStatus.LoginFailed);
-                } else if (err instanceof ConnectionError) {
+                } else if (err.name === "ConnectionError") {
                     this._loginFailure = LoginFailure.Connection;
                     this._status.set(LoadStatus.LoginFailed);
                 } else {
@@ -253,7 +252,7 @@ export class SessionContainer {
             }
         } catch (err) {
             // if dispose is called from stop, bail out
-            if (err instanceof AbortError) {
+            if (err.name === "AbortError") {
                 return;
             }
             throw err;

--- a/src/matrix/net/HomeServerApi.js
+++ b/src/matrix/net/HomeServerApi.js
@@ -19,13 +19,12 @@ import {encodeQueryParams, encodeBody} from "./common.js";
 import {HomeServerRequest} from "./HomeServerRequest.js";
 
 export class HomeServerApi {
-    constructor({homeServer, accessToken, request, createTimeout, reconnector}) {
+    constructor({homeServer, accessToken, request, reconnector}) {
         // store these both in a closure somehow so it's harder to get at in case of XSS?
         // one could change the homeserver as well so the token gets sent there, so both must be protected from read/write
         this._homeserver = homeServer;
         this._accessToken = accessToken;
         this._requestFn = request;
-        this._createTimeout = createTimeout;
         this._reconnector = reconnector;
     }
 


### PR DESCRIPTION
Fixes #264 

This does not yet handle connection errors during the /login or /keys/upload request that happen prior to the first sync though. That's a bit harder to fix, and most people reporting this issue seem to have it during /filter or /sync, which will be caught by this.