### PR TITLE
Dont assume there is a rooms section in the sync

### DIFF
--- a/src/matrix/Sync.js
+++ b/src/matrix/Sync.js
@@ -375,7 +375,7 @@ export class Sync {
 
     _parseInvites(roomsSection) {
         const inviteStates = [];
-        if (roomsSection.invite) {
+        if (roomsSection?.invite) {
             for (const [roomId, roomResponse] of Object.entries(roomsSection.invite)) {
                 let invite = this._session.invites.get(roomId);
                 let isNewInvite = false;


### PR DESCRIPTION
Fixes `Sync failed because of TypeError: Cannot read property 'invite' of undefined`