### PR TITLE
Don't move rooms to lower sorting position once marked as read

### DIFF
--- a/src/domain/session/leftpanel/BaseTileViewModel.js
+++ b/src/domain/session/leftpanel/BaseTileViewModel.js
@@ -25,9 +25,6 @@ export class BaseTileViewModel extends ViewModel {
         super(options);
         this._isOpen = false;
         this._hidden = false;
-        if (options.isOpen) {
-            this.open();
-        }
     }
 
     get hidden() {
@@ -52,7 +49,9 @@ export class BaseTileViewModel extends ViewModel {
         if (!this._isOpen) {
             this._isOpen = true;
             this.emitChange("isOpen");
+            return true;
         }
+        return false;
     }
 
     get isOpen() {

--- a/src/domain/session/leftpanel/BaseTileViewModel.js
+++ b/src/domain/session/leftpanel/BaseTileViewModel.js
@@ -49,9 +49,7 @@ export class BaseTileViewModel extends ViewModel {
         if (!this._isOpen) {
             this._isOpen = true;
             this.emitChange("isOpen");
-            return true;
         }
-        return false;
     }
 
     get isOpen() {

--- a/src/domain/session/leftpanel/LeftPanelViewModel.js
+++ b/src/domain/session/leftpanel/LeftPanelViewModel.js
@@ -37,14 +37,15 @@ export class LeftPanelViewModel extends ViewModel {
     _mapTileViewModels(rooms, invites) {
         // join is not commutative, invites will take precedence over rooms
         return invites.join(rooms).mapValues((roomOrInvite, emitChange) => {
-            const isOpen = this.navigation.path.get("room")?.value === roomOrInvite.id;
             let vm;
             if (roomOrInvite.isInvite) {
-                vm = new InviteTileViewModel(this.childOptions({isOpen, invite: roomOrInvite, emitChange}));
+                vm = new InviteTileViewModel(this.childOptions({invite: roomOrInvite, emitChange}));
             } else {
-                vm = new RoomTileViewModel(this.childOptions({isOpen, room: roomOrInvite, emitChange}));
+                vm = new RoomTileViewModel(this.childOptions({room: roomOrInvite, emitChange}));
             }
+            const isOpen = this.navigation.path.get("room")?.value === roomOrInvite.id;
             if (isOpen) {
+                vm.open();
                 this._updateCurrentVM(vm);
             }
             return vm;

--- a/src/domain/session/leftpanel/RoomTileViewModel.js
+++ b/src/domain/session/leftpanel/RoomTileViewModel.js
@@ -17,16 +17,11 @@ limitations under the License.
 
 import {BaseTileViewModel} from "./BaseTileViewModel.js";
 
-function isSortedAsUnread(vm) {
-    return vm.isUnread || (vm.isOpen && vm._wasUnreadWhenOpening);
-}
-
 export class RoomTileViewModel extends BaseTileViewModel {
     constructor(options) {
         super(options);
         const {room} = options;
         this._room = room;
-        this._wasUnreadWhenOpening = false;
         this._url = this.urlCreator.openRoomActionUrl(this._room.id);
     }
 
@@ -56,12 +51,6 @@ export class RoomTileViewModel extends BaseTileViewModel {
                 return 1;
             }
             return -1;
-        }
-        if (isSortedAsUnread(this) !== isSortedAsUnread(other)) {
-            if (isSortedAsUnread(this)) {
-                return -1;
-            }
-            return 1;
         }
         const myTimestamp = myRoom.lastMessageTimestamp;
         const theirTimestamp = theirRoom.lastMessageTimestamp;
@@ -104,11 +93,5 @@ export class RoomTileViewModel extends BaseTileViewModel {
 
     get _avatarSource() {
         return this._room;
-    }
-
-    open() {
-        if (super.open()) {
-            this._wasUnreadWhenOpening = this._room.isUnread;
-        }
     }
 }

--- a/src/domain/session/leftpanel/RoomTileViewModel.js
+++ b/src/domain/session/leftpanel/RoomTileViewModel.js
@@ -105,4 +105,10 @@ export class RoomTileViewModel extends BaseTileViewModel {
     get _avatarSource() {
         return this._room;
     }
+
+    open() {
+        if (super.open()) {
+            this._wasUnreadWhenOpening = this._room.isUnread;
+        }
+    }
 }


### PR DESCRIPTION
This makes the room list sorted by low-prio, then activity, then name and doesn't take unread status into account anymore.