### PR TITLE
fix DM room names appearing as "Empty room"

### DIFF
--- a/src/matrix/room/Room.js
+++ b/src/matrix/room/Room.js
@@ -272,8 +272,8 @@ export class Room extends BaseRoom {
     /** @package */
     async load(summary, txn, log) {
         try {
-            super.load(summary, txn, log);
-            this._syncWriter.load(txn, log);
+            await super.load(summary, txn, log);
+            await this._syncWriter.load(txn, log);
         } catch (err) {
             throw new WrappedError(`Could not load room ${this._roomId}`, err);
         }


### PR DESCRIPTION
because we weren't properly awaiting the heroes to be loaded