### PR TITLE
Don't assume there is at least 1 tile before loading at top

### DIFF
--- a/src/domain/session/room/timeline/TimelineViewModel.js
+++ b/src/domain/session/room/timeline/TimelineViewModel.js
@@ -52,7 +52,7 @@ export class TimelineViewModel extends ViewModel {
             return true;
         }
         const firstTile = this._tiles.getFirst();
-        if (firstTile.shape === "gap") {
+        if (firstTile?.shape === "gap") {
             return await firstTile.fill();
         } else {
             const topReached = await this._timeline.loadAtTop(10);


### PR DESCRIPTION
it can happen that all tiles are not renderable, and we should just
keep calling loadAtTop