### PR TITLE
Don't assume container node exists when loading bundle

### DIFF
--- a/src/platform/web/ui/common.js
+++ b/src/platform/web/ui/common.js
@@ -14,10 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const container = document.querySelector(".hydrogen");
+let container;
 
 export function spinner(t, extraClasses = undefined) {
-    if (container.classList.contains("legacy")) {
+    if (container === undefined) {
+        container = document.querySelector(".hydrogen");
+    }
+    if (container?.classList.contains("legacy")) {
         return t.div({className: "spinner"}, [
             t.div(),
             t.div(),


### PR DESCRIPTION
Only look for the container node when needed