### PR TITLE
Allow registering and logging in as guest

### DIFF
--- a/src/matrix/SessionContainer.js
+++ b/src/matrix/SessionContainer.js
@@ -97,7 +97,7 @@ export class SessionContainer {
         });
     }
 
-    async startWithLogin(homeServer, username, password) {
+    async startWithLogin(homeServer, username, password, guest = false) {
         if (this._status.get() !== LoadStatus.NotLoading) {
             return;
         }
@@ -109,7 +109,12 @@ export class SessionContainer {
             try {
                 const request = this._platform.request;
                 const hsApi = new HomeServerApi({homeServer, request});
-                const loginData = await hsApi.passwordLogin(username, password, "Hydrogen", {log}).response();
+                let loginData;
+                if (guest === true) {
+                    loginData = await hsApi.guestLogin("Hydrogen", {log}).response();
+                } else {
+                    loginData = await hsApi.passwordLogin(username, password, "Hydrogen", {log}).response();
+                }
                 const sessionId = this.createNewSessionId();
                 sessionInfo = {
                     id: sessionId,

--- a/src/matrix/net/HomeServerApi.js
+++ b/src/matrix/net/HomeServerApi.js
@@ -142,6 +142,12 @@ export class HomeServerApi {
         }, options);
     }
 
+    guestLogin(initialDeviceDisplayName, options = null) {
+        return this._unauthedRequest("POST", this._url(`/register`), {kind: 'guest'}, {
+            "initial_device_display_name": initialDeviceDisplayName
+        }, options);
+    }
+
     createFilter(userId, filter, options = null) {
         return this._post(`/user/${encodeURIComponent(userId)}/filter`, null, filter, options);
     }

--- a/src/platform/web/ui/common.js
+++ b/src/platform/web/ui/common.js
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const container = document.querySelector(".hydrogen");
 
 export function spinner(t, extraClasses = undefined) {
+    const container = document.querySelector(".hydrogen");
     if (container.classList.contains("legacy")) {
         return t.div({className: "spinner"}, [
             t.div(),


### PR DESCRIPTION
This PR is intended to enable (registering and) logging in as a guest user.

When `guest === true` is passed to startWithLogin the username and password parameters will be ignored (should be passed as `null`) and guest registration and login will be attempted. On success the registered username and accessToken will be returned to match a normal user / password login.
