### PR TITLE
Fix error on invites in room list panel.

### DIFF
--- a/src/matrix/room/Invite.js
+++ b/src/matrix/room/Invite.js
@@ -180,7 +180,7 @@ export class Invite extends EventEmitter {
     _createData(inviteState, myInvite, inviter, summaryData, heroes) {
         const name = heroes ? heroes.roomName : summaryData.name;
         const avatarUrl = heroes ? heroes.roomAvatarUrl : summaryData.avatarUrl;
-        const avatarColorId = heroes ? heroes.roomAvatarColorId : this.id;
+        const avatarColorId = heroes?.roomAvatarColorId || this.id;
         return {
             roomId: this.id,
             isEncrypted: !!summaryData.encryption,

--- a/src/matrix/room/Invite.js
+++ b/src/matrix/room/Invite.js
@@ -58,7 +58,7 @@ export class Invite extends EventEmitter {
 
     /** @see BaseRoom.avatarColorId */
     get avatarColorId() {
-        return this._inviteData.avatarColorId;
+        return this._inviteData.avatarColorId || this.id;
     }
 
     get timestamp() {


### PR DESCRIPTION
Frustratingly, the null-containing invites are saved to storage and will not be fixed by this.