### PR TITLE
Sending replies

### DIFF
--- a/doc/impl-thoughts/PENDING_REPLIES.md
+++ b/doc/impl-thoughts/PENDING_REPLIES.md
@@ -1,0 +1,25 @@
+# Replying to pending messages
+The matrix spec requires clients capable of rich replies (that would be us once replies work) to include fallback (textual in `body` and structured in `formatted_body`) that can be rendered
+by clients that do not natively support rich replies (that would be us at the time of writing). The schema for the fallback is as follows:
+
+```
+<mx-reply>
+  <blockquote>
+    <a href="https://matrix.to/#/!somewhere:example.org/$event:example.org">In reply to</a>
+    <a href="https://matrix.to/#/@alice:example.org">@alice:example.org</a>
+    <br />
+    <!-- This is where the related event's HTML would be. -->
+  </blockquote>
+</mx-reply>
+```
+
+There's a single complication here for pending events: we have `$event:example.org` in the schema (the `In reply to` link), and it must
+be present _within the content_, inside `formatted_body`. The issue is that, if we are queuing a reply to a pending event,
+we don't know its remote ID. All we know is its transaction ID on our end. If we were to use that while formatting the message,
+we'd be sending messages that contain our internal transaction IDs instead of proper matrix event identifiers.
+
+To solve this, we'd need `SendQueue`, whenever it receives a remote echo, to update pending events that are replies with their
+`relatedEventId`. This already happens, and the `event_id` field in `m.relates_to` is updated. But we'd need to extend this
+to adjust the messages' `formatted_body` with the resolved remote ID, too.
+
+How do we safely do this, without accidentally substituting event IDs into places in the body where they were not intended?

--- a/doc/impl-thoughts/REPLIES.md
+++ b/doc/impl-thoughts/REPLIES.md
@@ -1,0 +1,17 @@
+If we were to render replies in a smart way (instead of relying on the fallback), we would
+need to manually find entries that are pointed to be `in_reply_to`. Consulting the timeline
+code, it seems appropriate to add a `_replyingTo` field to a `BaseEventEntry` (much like we
+have `_pendingAnnotations` and `pendingRedactions`). We can then:
+* use `TilesCollection`'s `_findTileIdx` to find the tile of the message being replied to,
+  and put a reference to its tile into the new tile being created (?).
+  * It doesn't seem appropriate to add an additional argument to TileCreator, but we may
+    want to re-use tiles instead of creating duplicate ones. Otherwise, of course, `tileCreator`
+    can create more than one tile from an entry's `_replyingTo` field.
+* Resolve `_replyingTo` much like we resolve `redactingEntry` in timeline: search by `relatedTxnId`
+  and `relatedEventId` if our entry is a reply (we can add an `isReply` flag there).
+  * This works fine for local entries, which are loaded via an `AsyncMappedList`, but what
+    about remote entries? They are not loaded asynchronously, and the fact that they are
+    not a derived collection is used throughout `Timeline`.
+* Entries that don't have replies that are loadeded (but that are replies) probably need
+  to be tracked somehow?
+  * Then, on timeline add, check new IDs and update corresponding entries

--- a/src/domain/session/room/ComposerViewModel.js
+++ b/src/domain/session/room/ComposerViewModel.js
@@ -47,8 +47,8 @@ export class ComposerViewModel extends ViewModel {
         return this._roomVM.isEncrypted;
     }
 
-    sendMessage(message) {
-        const success = this._roomVM._sendMessage(message, this._replyVM);
+    async sendMessage(message) {
+        const success = await this._roomVM._sendMessage(message, this._replyVM);
         if (success) {
             this._isEmpty = true;
             this.emitChange("canSend");

--- a/src/domain/session/room/ComposerViewModel.js
+++ b/src/domain/session/room/ComposerViewModel.js
@@ -5,13 +5,23 @@ export class ComposerViewModel extends ViewModel {
         super();
         this._roomVM = roomVM;
         this._isEmpty = true;
+        this._replyId = null;
         this._replyVM = null;
     }
 
-    setReplyingTo(tile) {
-        const changed = this._replyVM !== tile;
-        this._replyVM = tile;
+    setReplyingTo(entry) {
+        const newId = entry?.id || null;
+        const changed = this._replyId !== newId;
         if (changed) {
+            this._replyId = newId;
+            if (this._replyVM) {
+                this.untrack(this._replyVM);
+                this._replyVM.dispose();
+            }
+            this._replyVM = entry && this._roomVM._createTile(entry);
+            if (this._replyVM) {
+                this.track(this._replyVM);
+            }
             this.emitChange("replyViewModel");
         }
     }

--- a/src/domain/session/room/ComposerViewModel.js
+++ b/src/domain/session/room/ComposerViewModel.js
@@ -1,0 +1,71 @@
+import {ViewModel} from "../../ViewModel.js";
+
+export class ComposerViewModel extends ViewModel {
+    constructor(roomVM) {
+        super();
+        this._roomVM = roomVM;
+        this._isEmpty = true;
+        this._replyVM = null;
+    }
+
+    setReplyingTo(tile) {
+        const changed = this._replyVM !== tile;
+        this._replyVM = tile;
+        if (changed) {
+            this.emitChange("replyViewModel");
+        }
+    }
+
+    clearReplyingTo() {
+        this.setReplyingTo(null);
+    }
+
+    get replyViewModel() {
+        return this._replyVM;
+    }
+
+    get isEncrypted() {
+        return this._roomVM.isEncrypted;
+    }
+
+    sendMessage(message) {
+        const success = this._roomVM._sendMessage(message, this._replyVM);
+        if (success) {
+            this._isEmpty = true;
+            this.emitChange("canSend");
+            this.clearReplyingTo();
+        }
+        return success;
+    }
+
+    sendPicture() {
+        this._roomVM._pickAndSendPicture();
+    }
+
+    sendFile() {
+        this._roomVM._pickAndSendFile();
+    }
+
+    sendVideo() {
+        this._roomVM._pickAndSendVideo();
+    }
+
+    get canSend() {
+        return !this._isEmpty;
+    }
+
+    async setInput(text) {
+        const wasEmpty = this._isEmpty;
+        this._isEmpty = text.length === 0;
+        if (wasEmpty && !this._isEmpty) {
+            this._roomVM._room.ensureMessageKeyIsShared();
+        }
+        if (wasEmpty !== this._isEmpty) {
+            this.emitChange("canSend");
+        }
+    }
+
+    get kind() {
+        return "composer";
+    }
+}

--- a/src/domain/session/room/ComposerViewModel.js
+++ b/src/domain/session/room/ComposerViewModel.js
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import {ViewModel} from "../../ViewModel.js";
 
 export class ComposerViewModel extends ViewModel {

--- a/src/domain/session/room/ComposerViewModel.js
+++ b/src/domain/session/room/ComposerViewModel.js
@@ -21,15 +21,12 @@ export class ComposerViewModel extends ViewModel {
         super();
         this._roomVM = roomVM;
         this._isEmpty = true;
-        this._replyId = null;
         this._replyVM = null;
     }
 
     setReplyingTo(entry) {
-        const newId = entry?.id || null;
-        const changed = this._replyId !== newId;
+        const changed = this._replyVM?.internalId !== entry?.asEventKey().toString();
         if (changed) {
-            this._replyId = newId;
             if (this._replyVM) {
                 this.untrack(this._replyVM);
                 this._replyVM.dispose();

--- a/src/domain/session/room/ComposerViewModel.js
+++ b/src/domain/session/room/ComposerViewModel.js
@@ -27,13 +27,9 @@ export class ComposerViewModel extends ViewModel {
     setReplyingTo(entry) {
         const changed = this._replyVM?.internalId !== entry?.asEventKey().toString();
         if (changed) {
-            if (this._replyVM) {
-                this.untrack(this._replyVM);
-                this._replyVM.dispose();
-            }
-            this._replyVM = entry && this._roomVM._createTile(entry);
-            if (this._replyVM) {
-                this.track(this._replyVM);
+            this._replyVM = this.disposeTracked(this._replyVM);
+            if (entry) {
+                this._replyVM = this.track(this._roomVM._createTile(entry));
             }
             this.emitChange("replyViewModel");
         }

--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -44,6 +44,7 @@ export class RoomViewModel extends ViewModel {
             const timeline = await this._room.openTimeline();
             const timelineVM = this.track(new TimelineViewModel(this.childOptions({
                 room: this._room,
+                roomVM: this,
                 timeline,
             })));
             this._timelineVM = timelineVM;
@@ -294,17 +295,35 @@ export class RoomViewModel extends ViewModel {
         path = path.with(this.navigation.segment("details", true));
         this.navigation.applyPath(path);
     }
+
+    setReply(entry) {
+        this._composerVM.setReply(entry);
+    }
 }
 
 class ComposerViewModel extends ViewModel {
     constructor(roomVM) {
         super();
         this._roomVM = roomVM;
+        this._replyTo = null;
         this._isEmpty = true;
     }
 
     get isEncrypted() {
         return this._roomVM.isEncrypted;
+    }
+
+    setReply(entry) {
+        this._replyTo = entry;
+        this.emitChange("replyTo");
+    }
+
+    clearReply() {
+        this.setReply(null);
+    }
+
+    get replyTo() {
+        return this._replyTo;
     }
 
     sendMessage(message) {

--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -18,6 +18,7 @@ limitations under the License.
 import {TimelineViewModel} from "./timeline/TimelineViewModel.js";
 import {ComposerViewModel} from "./ComposerViewModel.js"
 import {avatarInitials, getIdentifierColorNumber, getAvatarHttpUrl} from "../../avatar.js";
+import {tilesCreator} from "./timeline/tilesCreator.js";
 import {ViewModel} from "../../ViewModel.js";
 
 export class RoomViewModel extends ViewModel {
@@ -26,6 +27,7 @@ export class RoomViewModel extends ViewModel {
         const {room} = options;
         this._room = room;
         this._timelineVM = null;
+        this._tilesCreator = null;
         this._onRoomChange = this._onRoomChange.bind(this);
         this._timelineError = null;
         this._sendError = null;
@@ -43,12 +45,15 @@ export class RoomViewModel extends ViewModel {
         this._room.on("change", this._onRoomChange);
         try {
             const timeline = await this._room.openTimeline();
-            const timelineVM = this.track(new TimelineViewModel(this.childOptions({
+            this._tilesCreator = tilesCreator(this.childOptions({
                 room: this._room,
                 roomVM: this,
                 timeline,
+            }));
+            this._timelineVM = this.track(new TimelineViewModel(this.childOptions({
+                tilesCreator: this._tilesCreator,
+                timeline,
             })));
-            this._timelineVM = timelineVM;
             this.emitChange("timelineViewModel");
         } catch (err) {
             console.error(`room.openTimeline(): ${err.message}:\n${err.stack}`);

--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -155,7 +155,7 @@ export class RoomViewModel extends ViewModel {
         this._room.join();
     }
     
-    async _sendMessage(message, reply) {
+    async _sendMessage(message, replyingTo) {
         if (!this._room.isArchived && message) {
             try {
                 let msgtype = "m.text";
@@ -163,11 +163,11 @@ export class RoomViewModel extends ViewModel {
                     message = message.substr(4).trim();
                     msgtype = "m.emote";
                 }
-                const content = {msgtype, body: message};
-                if (reply) {
-                    content["m.relates_to"] = reply;
+                if (replyingTo) {
+                    await replyingTo.reply(msgtype, message);
+                } else {
+                    await this._room.sendEvent("m.room.message", {msgtype, body: message});
                 }
-                await this._room.sendEvent("m.room.message", content);
             } catch (err) {
                 console.error(`room.sendMessage(): ${err.message}:\n${err.stack}`);
                 this._sendError = err;
@@ -336,7 +336,7 @@ class ComposerViewModel extends ViewModel {
     }
 
     sendMessage(message) {
-        const success = this._roomVM._sendMessage(message, this._replyVM?.reply());
+        const success = this._roomVM._sendMessage(message, this._replyVM);
         if (success) {
             this._isEmpty = true;
             this.emitChange("canSend");

--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -160,6 +160,10 @@ export class RoomViewModel extends ViewModel {
     rejoinRoom() {
         this._room.join();
     }
+
+    _createTile(entry) {
+        return this._tilesCreator(entry);
+    }
     
     async _sendMessage(message, replyingTo) {
         if (!this._room.isArchived && message) {

--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -46,7 +46,6 @@ export class RoomViewModel extends ViewModel {
         try {
             const timeline = await this._room.openTimeline();
             this._tilesCreator = tilesCreator(this.childOptions({
-                room: this._room,
                 roomVM: this,
                 timeline,
             }));
@@ -297,6 +296,10 @@ export class RoomViewModel extends ViewModel {
             this.emitChange("error");
             console.error(err.stack);
         }
+    }
+
+    get room() {
+        return this._room;
     }
 
     get composerViewModel() {

--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -175,6 +175,7 @@ export class RoomViewModel extends ViewModel {
                 this.emitChange("error");
                 return false;
             }
+            this.setReply(null);
             return true;
         }
         return false;

--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -155,7 +155,7 @@ export class RoomViewModel extends ViewModel {
         this._room.join();
     }
     
-    async _sendMessage(message) {
+    async _sendMessage(message, replyTo) {
         if (!this._room.isArchived && message) {
             try {
                 let msgtype = "m.text";
@@ -163,7 +163,11 @@ export class RoomViewModel extends ViewModel {
                     message = message.substr(4).trim();
                     msgtype = "m.emote";
                 }
-                await this._room.sendEvent("m.room.message", {msgtype, body: message});
+                const content = {msgtype, body: message};
+                if (replyTo) {
+                    content["m.relates_to"] = replyTo.reply();
+                }
+                await this._room.sendEvent("m.room.message", content);
             } catch (err) {
                 console.error(`room.sendMessage(): ${err.message}:\n${err.stack}`);
                 this._sendError = err;
@@ -327,7 +331,7 @@ class ComposerViewModel extends ViewModel {
     }
 
     sendMessage(message) {
-        const success = this._roomVM._sendMessage(message);
+        const success = this._roomVM._sendMessage(message, this._replyTo);
         if (success) {
             this._isEmpty = true;
             this.emitChange("canSend");

--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import {TimelineViewModel} from "./timeline/TimelineViewModel.js";
+import {ComposerViewModel} from "./ComposerViewModel.js"
 import {avatarInitials, getIdentifierColorNumber, getAvatarHttpUrl} from "../../avatar.js";
 import {ViewModel} from "../../ViewModel.js";
 
@@ -304,76 +305,6 @@ export class RoomViewModel extends ViewModel {
         if (!this._room.isArchived) {
             this._composerVM.setReplyingTo(entry);
         }
-    }
-}
-
-class ComposerViewModel extends ViewModel {
-    constructor(roomVM) {
-        super();
-        this._roomVM = roomVM;
-        this._isEmpty = true;
-        this._replyVM = null;
-    }
-
-    setReplyingTo(tile) {
-        const changed = this._replyVM !== tile;
-        this._replyVM = tile;
-        if (changed) {
-            this.emitChange("replyViewModel");
-        }
-    }
-
-    clearReplyingTo() {
-        this.setReplyingTo(null);
-    }
-
-    get replyViewModel() {
-        return this._replyVM;
-    }
-
-    get isEncrypted() {
-        return this._roomVM.isEncrypted;
-    }
-
-    sendMessage(message) {
-        const success = this._roomVM._sendMessage(message, this._replyVM);
-        if (success) {
-            this._isEmpty = true;
-            this.emitChange("canSend");
-            this.clearReplyingTo();
-        }
-        return success;
-    }
-
-    sendPicture() {
-        this._roomVM._pickAndSendPicture();
-    }
-
-    sendFile() {
-        this._roomVM._pickAndSendFile();
-    }
-
-    sendVideo() {
-        this._roomVM._pickAndSendVideo();
-    }
-
-    get canSend() {
-        return !this._isEmpty;
-    }
-
-    async setInput(text) {
-        const wasEmpty = this._isEmpty;
-        this._isEmpty = text.length === 0;
-        if (wasEmpty && !this._isEmpty) {
-            this._roomVM._room.ensureMessageKeyIsShared();
-        }
-        if (wasEmpty !== this._isEmpty) {
-            this.emitChange("canSend");
-        }
-    }
-
-    get kind() {
-        return "composer";
     }
 }
 

--- a/src/domain/session/room/timeline/MessageBody.js
+++ b/src/domain/session/room/timeline/MessageBody.js
@@ -137,6 +137,10 @@ export class TextPart {
     get type() { return "text"; }
 }
 
+function isBlockquote(part){
+    return part.type === "format" && part.format === "blockquote";
+}
+
 export class MessageBody {
     constructor(sourceString, parts) {
         this.sourceString = sourceString;
@@ -148,7 +152,7 @@ export class MessageBody {
         // We assume that such quotes are not TextParts, because replies
         // must have a formatted body.
         let i = 0;
-        for (i = 0; i < this.parts.length && this.parts[i].type === "format" && this.parts[i].format === "blockquote"; i++);
+        for (; i < this.parts.length && isBlockquote(this.parts[i]); i++);
         this.parts.splice(i, 0, new TextPart(string));
     }
 }

--- a/src/domain/session/room/timeline/MessageBody.js
+++ b/src/domain/session/room/timeline/MessageBody.js
@@ -142,6 +142,15 @@ export class MessageBody {
         this.sourceString = sourceString;
         this.parts = parts;
     }
+
+    insertEmote(string) {
+        // We want to skip quotes introduced by replies when emoting.
+        // We assume that such quotes are not TextParts, because replies
+        // must have a formatted body.
+        let i = 0;
+        for (i = 0; i < this.parts.length && this.parts[i].type === "format" && this.parts[i].format === "blockquote"; i++);
+        this.parts.splice(i, 0, new TextPart(string));
+    }
 }
 
 export function tests() {

--- a/src/domain/session/room/timeline/ReactionsViewModel.js
+++ b/src/domain/session/room/timeline/ReactionsViewModel.js
@@ -222,7 +222,7 @@ export function tests() {
         };
         const tiles = new MappedList(timeline.entries, entry => {
             if (entry.eventType === "m.room.message") {
-                return new BaseMessageTile({entry, room, timeline, platform: {logger}});
+                return new BaseMessageTile({entry, roomVM: {room}, timeline, platform: {logger}});
             }
             return null;
         }, (tile, params, entry) => tile?.updateEntry(entry, params));

--- a/src/domain/session/room/timeline/TilesCollection.js
+++ b/src/domain/session/room/timeline/TilesCollection.js
@@ -181,6 +181,8 @@ export class TilesCollection extends BaseObservableList {
     }
 
     _replaceTile(tileIdx, existingTile, newTile, updateParams) {
+        // TODO What happens with a tile that's being replied to? Can we have
+        //      reference counting of some sort?
         existingTile.dispose();
         const prevTile = this._getTileAtIdx(tileIdx - 1);
         const nextTile = this._getTileAtIdx(tileIdx + 1);

--- a/src/domain/session/room/timeline/TilesCollection.js
+++ b/src/domain/session/room/timeline/TilesCollection.js
@@ -181,8 +181,6 @@ export class TilesCollection extends BaseObservableList {
     }
 
     _replaceTile(tileIdx, existingTile, newTile, updateParams) {
-        // TODO What happens with a tile that's being replied to? Can we have
-        //      reference counting of some sort?
         existingTile.dispose();
         const prevTile = this._getTileAtIdx(tileIdx - 1);
         const nextTile = this._getTileAtIdx(tileIdx + 1);

--- a/src/domain/session/room/timeline/TimelineViewModel.js
+++ b/src/domain/session/room/timeline/TimelineViewModel.js
@@ -38,9 +38,9 @@ import {ViewModel} from "../../../ViewModel.js";
 export class TimelineViewModel extends ViewModel {
     constructor(options) {
         super(options);
-        const {room, timeline} = options;
+        const {room, timeline, roomVM} = options;
         this._timeline = this.track(timeline);
-        this._tiles = new TilesCollection(timeline.entries, tilesCreator(this.childOptions({room, timeline})));
+        this._tiles = new TilesCollection(timeline.entries, tilesCreator(this.childOptions({room, timeline, roomVM})));
     }
 
     /**

--- a/src/domain/session/room/timeline/TimelineViewModel.js
+++ b/src/domain/session/room/timeline/TimelineViewModel.js
@@ -32,15 +32,14 @@ to the room timeline, which unload entries from memory.
 when loading, it just reads events from a sortkey backwards or forwards...
 */
 import {TilesCollection} from "./TilesCollection.js";
-import {tilesCreator} from "./tilesCreator.js";
 import {ViewModel} from "../../../ViewModel.js";
 
 export class TimelineViewModel extends ViewModel {
     constructor(options) {
         super(options);
-        const {room, timeline, roomVM} = options;
+        const {timeline, tilesCreator} = options;
         this._timeline = this.track(timeline);
-        this._tiles = new TilesCollection(timeline.entries, tilesCreator(this.childOptions({room, timeline, roomVM})));
+        this._tiles = new TilesCollection(timeline.entries, tilesCreator);
     }
 
     /**

--- a/src/domain/session/room/timeline/deserialize.js
+++ b/src/domain/session/room/timeline/deserialize.js
@@ -398,7 +398,7 @@ export function tests() {
     };
 
     function test(assert, input, output) {
-        assert.deepEqual(parseHTMLBody(platform, null, input), new MessageBody(input, output));
+        assert.deepEqual(parseHTMLBody(platform, null, true, input), new MessageBody(input, output));
     }
 
     return {

--- a/src/domain/session/room/timeline/deserialize.js
+++ b/src/domain/session/room/timeline/deserialize.js
@@ -397,8 +397,8 @@ export function tests() {
         parseHTML: (html) => new HTMLParseResult(parse(html))
     };
 
-    function test(assert, input, output) {
-        assert.deepEqual(parseHTMLBody(platform, null, true, input), new MessageBody(input, output));
+    function test(assert, input, output, replies=true) {
+        assert.deepEqual(parseHTMLBody(platform, null, replies, input), new MessageBody(input, output));
     }
 
     return {
@@ -495,6 +495,24 @@ export function tests() {
                 new CodeBlock(null, code)
             ];
             test(assert, input, output);
+        },
+        "Replies are inserted when allowed": assert => {
+            const input = 'Hello, <em><mx-reply>World</mx-reply></em>!';
+            const output = [
+                new TextPart('Hello, '),
+                new FormatPart("em", [new TextPart('World')]),
+                new TextPart('!'),
+            ];
+            test(assert, input, output);
+        },
+        "Replies are stripped when not allowed": assert => {
+            const input = 'Hello, <em><mx-reply>World</mx-reply></em>!';
+            const output = [
+                new TextPart('Hello, '),
+                new FormatPart("em", []),
+                new TextPart('!'),
+            ];
+            test(assert, input, output, false);
         }
         /* Doesnt work: HTML library doesn't handle <pre><code> properly.
         "Text with code block": assert => {

--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -106,6 +106,10 @@ export class BaseMessageTile extends SimpleTile {
         return action;
     }
 
+    setReply() {
+        this._roomVM.setReply(this._entry);
+    }
+
     redact(reason, log) {
         return this._room.sendRedaction(this._entry.id, reason, log);
     }

--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -110,8 +110,8 @@ export class BaseMessageTile extends SimpleTile {
         this._roomVM.startReply(this);
     }
 
-    reply() {
-        return this._entry.reply();
+    reply(msgtype, body) {
+        return this._room.sendEvent("m.room.message", this._entry.reply(msgtype, body));
     }
 
     redact(reason, log) {

--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -107,7 +107,7 @@ export class BaseMessageTile extends SimpleTile {
     }
 
     startReply() {
-        this._roomVM.startReply(this);
+        this._roomVM.startReply(this._entry);
     }
 
     reply(msgtype, body, log = null) {

--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -110,8 +110,8 @@ export class BaseMessageTile extends SimpleTile {
         this._roomVM.startReply(this);
     }
 
-    reply(msgtype, body) {
-        return this._room.sendEvent("m.room.message", this._entry.reply(msgtype, body));
+    reply(msgtype, body, log = null) {
+        return this._room.sendEvent("m.room.message", this._entry.reply(msgtype, body), null, log);
     }
 
     redact(reason, log) {

--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -107,7 +107,11 @@ export class BaseMessageTile extends SimpleTile {
     }
 
     startReply() {
-        this._roomVM.startReply(this._entry);
+        this._roomVM.startReply(this);
+    }
+
+    reply() {
+        return this._entry.reply();
     }
 
     redact(reason, log) {

--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -106,8 +106,8 @@ export class BaseMessageTile extends SimpleTile {
         return action;
     }
 
-    setReply() {
-        this._roomVM.setReply(this._entry);
+    startReply() {
+        this._roomVM.startReply(this._entry);
     }
 
     redact(reason, log) {

--- a/src/domain/session/room/timeline/tiles/GapTile.js
+++ b/src/domain/session/room/timeline/tiles/GapTile.js
@@ -91,7 +91,7 @@ export function tests() {
                     tile.updateEntry(newEntry);
                 }
             };
-            const tile = new GapTile({entry: new FragmentBoundaryEntry(fragment, true), room});
+            const tile = new GapTile({entry: new FragmentBoundaryEntry(fragment, true), roomVM: {room}});
             await tile.fill();
             await tile.fill();
             await tile.fill();

--- a/src/domain/session/room/timeline/tiles/SimpleTile.js
+++ b/src/domain/session/room/timeline/tiles/SimpleTile.js
@@ -129,6 +129,10 @@ export class SimpleTile extends ViewModel {
         return this._options.room;
     }
 
+    get _roomVM() {
+        return this._options.roomVM;
+    }
+
     get _timeline() {
         return this._options.timeline;
     }

--- a/src/domain/session/room/timeline/tiles/SimpleTile.js
+++ b/src/domain/session/room/timeline/tiles/SimpleTile.js
@@ -126,7 +126,7 @@ export class SimpleTile extends ViewModel {
     // TilesCollection contract above
 
     get _room() {
-        return this._options.room;
+        return this._roomVM.room;
     }
 
     get _roomVM() {

--- a/src/domain/session/room/timeline/tiles/TextTile.js
+++ b/src/domain/session/room/timeline/tiles/TextTile.js
@@ -20,12 +20,7 @@ import {parseHTMLBody} from "../deserialize.js";
 
 export class TextTile extends BaseTextTile {
     _getContentString(key) {
-        const content = this._getContent();
-        let val = content?.[key] || "";
-        if (content.msgtype === "m.emote") {
-            val = `* ${this.displayName} ${val}`;
-        }
-        return val;
+        return this._getContent()?.[key] || "";
     }
 
     _getPlainBody() {
@@ -53,10 +48,15 @@ export class TextTile extends BaseTextTile {
     }
 
     _parseBody(body, format) {
+        let messageBody;
         if (format === BodyFormat.Html) {
-            return parseHTMLBody(this.platform, this._mediaRepository, this._entry.isReply, body);
+            messageBody = parseHTMLBody(this.platform, this._mediaRepository, this._entry.isReply, body);
         } else {
-            return parsePlainBody(body);
+            messageBody = parsePlainBody(body);
         }
+        if (this._getContent()?.msgtype === "m.emote") {
+            messageBody.insertEmote(`* ${this.displayName} `);
+        }
+        return messageBody;
     }
 }

--- a/src/domain/session/room/timeline/tiles/TextTile.js
+++ b/src/domain/session/room/timeline/tiles/TextTile.js
@@ -54,7 +54,7 @@ export class TextTile extends BaseTextTile {
 
     _parseBody(body, format) {
         if (format === BodyFormat.Html) {
-            return parseHTMLBody(this.platform, this._mediaRepository, body);
+            return parseHTMLBody(this.platform, this._mediaRepository, this._entry.isReply, body);
         } else {
             return parsePlainBody(body);
         }

--- a/src/matrix/room/sending/PendingEvent.js
+++ b/src/matrix/room/sending/PendingEvent.js
@@ -28,6 +28,10 @@ export const SendStatus = createEnum(
     "Error",
 );
 
+const preservedContentFields = {
+    "m.room.message": [ "m.relates_to" ]
+};
+
 export class PendingEvent {
     constructor({data, remove, emitUpdate, attachments}) {
         this._data = data;
@@ -96,7 +100,20 @@ export class PendingEvent {
         this._emitUpdate("status");
     }
 
+    _preserveContentFields(into) {
+        const preservedFields = preservedContentFields[this.eventType];
+        if (preservedFields) {
+            const content = this._data.content;
+            for (const field of preservedFields) {
+                if (content[field] !== undefined) {
+                    into[field] = content[field];
+                }
+            }
+        }
+    }
+
     setEncrypted(type, content) {
+        this._preserveContentFields(content);
         this._data.encryptedEventType = type;
         this._data.encryptedContent = content;
         this._data.needsEncryption = false;

--- a/src/matrix/room/sending/PendingEvent.js
+++ b/src/matrix/room/sending/PendingEvent.js
@@ -28,7 +28,7 @@ export const SendStatus = createEnum(
     "Error",
 );
 
-const preservedContentFields = [ "m.relates_to" ];
+const unencryptedContentFields = [ "m.relates_to" ];
 
 export class PendingEvent {
     constructor({data, remove, emitUpdate, attachments}) {
@@ -98,9 +98,9 @@ export class PendingEvent {
         this._emitUpdate("status");
     }
 
-    get cleanedContent() {
+    get contentForEncryption() {
         const content = Object.assign({}, this._data.content);
-        for (const field of preservedContentFields) {
+        for (const field of unencryptedContentFields) {
             delete content[field];
         }
         return content;
@@ -108,7 +108,7 @@ export class PendingEvent {
 
     _preserveContentFields(into) {
         const content = this._data.content;
-        for (const field of preservedContentFields) {
+        for (const field of unencryptedContentFields) {
             if (content[field] !== undefined) {
                 into[field] = content[field];
             }

--- a/src/matrix/room/sending/PendingEvent.js
+++ b/src/matrix/room/sending/PendingEvent.js
@@ -28,9 +28,7 @@ export const SendStatus = createEnum(
     "Error",
 );
 
-const preservedContentFields = {
-    "m.room.message": [ "m.relates_to" ]
-};
+const preservedContentFields = [ "m.relates_to" ];
 
 export class PendingEvent {
     constructor({data, remove, emitUpdate, attachments}) {
@@ -100,14 +98,19 @@ export class PendingEvent {
         this._emitUpdate("status");
     }
 
+    get cleanedContent() {
+        const content = Object.assign({}, this._data.content);
+        for (const field of preservedContentFields) {
+            delete content[field];
+        }
+        return content;
+    }
+
     _preserveContentFields(into) {
-        const preservedFields = preservedContentFields[this.eventType];
-        if (preservedFields) {
-            const content = this._data.content;
-            for (const field of preservedFields) {
-                if (content[field] !== undefined) {
-                    into[field] = content[field];
-                }
+        const content = this._data.content;
+        for (const field of preservedContentFields) {
+            if (content[field] !== undefined) {
+                into[field] = content[field];
             }
         }
     }

--- a/src/matrix/room/sending/PendingEvent.js
+++ b/src/matrix/room/sending/PendingEvent.js
@@ -16,7 +16,7 @@ limitations under the License.
 import {createEnum} from "../../../utils/enum.js";
 import {AbortError} from "../../../utils/error.js";
 import {REDACTION_TYPE} from "../common.js";
-import {getRelationFromContent} from "../timeline/relations.js";
+import {getRelationFromContent, getRelationTarget, setRelationTarget} from "../timeline/relations.js";
 
 export const SendStatus = createEnum(
     "Waiting",
@@ -54,7 +54,7 @@ export class PendingEvent {
         const relation = getRelationFromContent(this.content);
         if (relation) {
             // may be null when target is not sent yet, is intended
-            return relation.event_id;
+            return getRelationTarget(relation);
         } else {
             return this._data.relatedEventId;
         }
@@ -63,7 +63,7 @@ export class PendingEvent {
     setRelatedEventId(eventId) {
         const relation = getRelationFromContent(this.content);
         if (relation) {
-            relation.event_id = eventId;
+            setRelationTarget(relation, eventId);
         } else {
             this._data.relatedEventId = eventId;
         }

--- a/src/matrix/room/sending/SendQueue.js
+++ b/src/matrix/room/sending/SendQueue.js
@@ -97,9 +97,9 @@ export class SendQueue {
         }
         if (pendingEvent.needsEncryption) {
             pendingEvent.setEncrypting();
-            const cleanedContent = pendingEvent.cleanedContent;
+            const encryptionContent = pendingEvent.contentForEncryption;
             const {type, content} = await log.wrap("encrypt", log => this._roomEncryption.encrypt(
-                pendingEvent.eventType, cleanedContent, this._hsApi, log));
+                pendingEvent.eventType, encryptionContent, this._hsApi, log));
             pendingEvent.setEncrypted(type, content);
             await this._tryUpdateEvent(pendingEvent);
         }

--- a/src/matrix/room/sending/SendQueue.js
+++ b/src/matrix/room/sending/SendQueue.js
@@ -97,8 +97,9 @@ export class SendQueue {
         }
         if (pendingEvent.needsEncryption) {
             pendingEvent.setEncrypting();
+            const cleanedContent = pendingEvent.cleanedContent;
             const {type, content} = await log.wrap("encrypt", log => this._roomEncryption.encrypt(
-                pendingEvent.eventType, pendingEvent.content, this._hsApi, log));
+                pendingEvent.eventType, cleanedContent, this._hsApi, log));
             pendingEvent.setEncrypted(type, content);
             await this._tryUpdateEvent(pendingEvent);
         }

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import {BaseEntry} from "./BaseEntry.js";
 import {REDACTION_TYPE} from "../../common.js";
-import {createAnnotation, ANNOTATION_RELATION_TYPE, getRelationFromContent} from "../relations.js";
+import {createAnnotation, createReply, ANNOTATION_RELATION_TYPE, getRelationFromContent} from "../relations.js";
 import {PendingAnnotation} from "../PendingAnnotation.js";
 
 /** Deals mainly with local echo for relations and redactions,
@@ -149,6 +149,10 @@ export class BaseEventEntry extends BaseEntry {
 
     annotate(key) {
         return createAnnotation(this.id, key);
+    }
+
+    reply() {
+        return createReply(this.id);
     }
 
     /** takes both remote event id and local txn id into account, see overriding in PendingEventEntry */

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -151,8 +151,18 @@ export class BaseEventEntry extends BaseEntry {
         return createAnnotation(this.id, key);
     }
 
+    _formatReplyBody() {
+        // This is just a rough sketch for now.
+        // TODO case-by-case formatting
+        // TODO check for absense?
+        const bodyLines = this.content.body.split("\n");
+        const sender = this.sender;
+        bodyLines[0] = `<${sender}> ${bodyLines[0]}`
+        return `> ${bodyLines.join("\n> ")}\n\n`;
+    }
+
     reply(msgtype, body) {
-        return createReply(this.id, msgtype, body);
+        return createReply(this.id, msgtype, this._formatReplyBody() + body);
     }
 
     /** takes both remote event id and local txn id into account, see overriding in PendingEventEntry */

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -190,10 +190,10 @@ export class BaseEventEntry extends BaseEntry {
             <br />
             ${body}
           </blockquote>
-        </mx-reply>`
+        </mx-reply>`;
     }
 
-    _replyBodyFallback() {
+    _replyPlainFallback() {
         const body = this._fallbackBlurb() || this._plainBody || "";
         const bodyLines = body.split("\n");
         bodyLines[0] = `> <${this.sender}> ${bodyLines[0]}`
@@ -202,7 +202,7 @@ export class BaseEventEntry extends BaseEntry {
 
     reply(msgtype, body) {
         // TODO check for absense of sender / body / msgtype / etc?
-        const newBody = this._replyBodyFallback() + '\n\n' + body;
+        const newBody = this._replyPlainFallback() + '\n\n' + body;
         const newFormattedBody = this._replyFormattedFallback() + htmlEscape(body);
         return createReply(this.id, msgtype, newBody, newFormattedBody);
     }

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -18,7 +18,7 @@ import {BaseEntry} from "./BaseEntry.js";
 import {REDACTION_TYPE} from "../../common.js";
 import {createAnnotation, ANNOTATION_RELATION_TYPE, getRelationFromContent} from "../relations.js";
 import {PendingAnnotation} from "../PendingAnnotation.js";
-import {reply} from "./reply.js"
+import {createReplyContent} from "./reply.js"
 
 /** Deals mainly with local echo for relations and redactions,
  * so it is shared between PendingEventEntry and EventEntry */
@@ -157,7 +157,7 @@ export class BaseEventEntry extends BaseEntry {
     }
 
     reply(msgtype, body) {
-        return reply(this, msgtype, body);
+        return createReplyContent(this, msgtype, body);
     }
 
     /** takes both remote event id and local txn id into account, see overriding in PendingEventEntry */

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -29,6 +29,10 @@ export class BaseEventEntry extends BaseEntry {
         this._pendingAnnotations = null;
     }
 
+    get isReply() {
+        return !!this.relation?.["m.in_reply_to"];
+    }
+
     get isRedacting() {
         return !!this._pendingRedactions;
     }

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -18,11 +18,7 @@ import {BaseEntry} from "./BaseEntry.js";
 import {REDACTION_TYPE} from "../../common.js";
 import {createAnnotation, ANNOTATION_RELATION_TYPE, getRelationFromContent} from "../relations.js";
 import {PendingAnnotation} from "../PendingAnnotation.js";
-import {createReply, fallbackBlurb, fallbackPrefix} from "./reply.js"
-
-function htmlEscape(string) {
-    return string.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
+import {reply} from "./reply.js"
 
 /** Deals mainly with local echo for relations and redactions,
  * so it is shared between PendingEventEntry and EventEntry */
@@ -157,26 +153,7 @@ export class BaseEventEntry extends BaseEntry {
     }
 
     reply(msgtype, body) {
-        // TODO check for absense of sender / body / msgtype / etc?
-        let blurb = fallbackBlurb(this.content.msgtype);
-        const prefix = fallbackPrefix(this.content.msgtype);
-        const sender = this.sender;
-        const name = this.displayName || sender;
-
-        const formattedBody = blurb || this.content.formatted_body ||
-            (this.content.body && htmlEscape(this.content.body)) || "";
-        const formattedFallback = `<mx-reply><blockquote>In reply to ${prefix}` +
-            `<a href="https://matrix.to/#/${sender}">${name}</a><br />` +
-            `${formattedBody}</blockquote></mx-reply>`;
-
-        const plainBody = blurb || this.content.body || "";
-        const bodyLines = plainBody.split("\n");
-        bodyLines[0] = `> ${prefix}<${sender}> ${bodyLines[0]}`
-        const plainFallback = bodyLines.join("\n> ");
-
-        const newBody = plainFallback + '\n\n' + body;
-        const newFormattedBody = formattedFallback + htmlEscape(body);
-        return createReply(this.id, msgtype, newBody, newFormattedBody);
+        return reply(this, msgtype, body);
     }
 
     /** takes both remote event id and local txn id into account, see overriding in PendingEventEntry */

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -170,7 +170,7 @@ export class BaseEventEntry extends BaseEntry {
 
     _replyFormattedFallback() {
         // TODO check for absense?
-        // TODO escape unformatted body if needed
+        // TODO escape and tranform unformatted body as needed
         const body = this._fallbackBlurb() || this.content.formatted_body || this.content.body;
         const prefix = this._fallbackPrefix();
         return `<mx-reply>
@@ -192,7 +192,9 @@ export class BaseEventEntry extends BaseEntry {
     }
 
     reply(msgtype, body) {
-        return createReply(this.id, msgtype, this._replyBodyFallback() + '\n\n' + body);
+        const newBody = this._replyBodyFallback() + '\n\n' + body;
+        const newFormattedBody = this._replyFormattedFallback() + body;
+        return createReply(this.id, msgtype, newBody, newFormattedBody);
     }
 
     /** takes both remote event id and local txn id into account, see overriding in PendingEventEntry */

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -151,8 +151,8 @@ export class BaseEventEntry extends BaseEntry {
         return createAnnotation(this.id, key);
     }
 
-    reply() {
-        return createReply(this.id);
+    reply(msgtype, body) {
+        return createReply(this.id, msgtype, body);
     }
 
     /** takes both remote event id and local txn id into account, see overriding in PendingEventEntry */

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 import {BaseEventEntry} from "./BaseEventEntry.js";
 import {getPrevContentFromStateEvent, isRedacted} from "../../common.js";
-import {getRelatedEventId} from "../relations.js";
+import {getRelationFromContent, getRelatedEventId} from "../relations.js";
 
 export class EventEntry extends BaseEventEntry {
     constructor(eventEntry, fragmentIdComparer) {
@@ -138,6 +138,12 @@ export class EventEntry extends BaseEventEntry {
 
     get annotations() {
         return this._eventEntry.annotations;
+    }
+
+    get relation() {
+        const originalContent = this._eventEntry.event.content;
+        const originalRelation = originalContent && getRelationFromContent(originalContent);
+        return originalRelation || getRelationFromContent(this.content);
     }
 }
 

--- a/src/matrix/room/timeline/entries/reply.js
+++ b/src/matrix/room/timeline/entries/reply.js
@@ -18,7 +18,7 @@ function htmlEscape(string) {
     return string.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function fallbackBlurb(msgtype) {
+function fallbackForNonTextualMessage(msgtype) {
     switch (msgtype) {
         case "m.file":
             return "sent a file.";
@@ -52,18 +52,18 @@ function createReply(targetId, msgtype, body, formattedBody) {
 
 export function reply(entry, msgtype, body) {
     // TODO check for absense of sender / body / msgtype / etc?
-    let blurb = fallbackBlurb(entry.content.msgtype);
+    const nonTextual = fallbackForNonTextualMessage(entry.content.msgtype);
     const prefix = fallbackPrefix(entry.content.msgtype);
     const sender = entry.sender;
     const name = entry.displayName || sender;
 
-    const formattedBody = blurb || entry.content.formatted_body ||
+    const formattedBody = nonTextual || entry.content.formatted_body ||
         (entry.content.body && htmlEscape(entry.content.body)) || "";
     const formattedFallback = `<mx-reply><blockquote>In reply to ${prefix}` +
         `<a href="https://matrix.to/#/${sender}">${name}</a><br />` +
         `${formattedBody}</blockquote></mx-reply>`;
 
-    const plainBody = blurb || entry.content.body || "";
+    const plainBody = nonTextual || entry.content.body || "";
     const bodyLines = plainBody.split("\n");
     bodyLines[0] = `> ${prefix}<${sender}> ${bodyLines[0]}`
     const plainFallback = bodyLines.join("\n> ");

--- a/src/matrix/room/timeline/entries/reply.js
+++ b/src/matrix/room/timeline/entries/reply.js
@@ -36,7 +36,7 @@ function fallbackPrefix(msgtype) {
     return msgtype === "m.emote" ? "* " : "";
 }
 
-function createReply(targetId, msgtype, body, formattedBody) {
+function _createReplyContent(targetId, msgtype, body, formattedBody) {
     return {
         msgtype,
         body,
@@ -50,7 +50,7 @@ function createReply(targetId, msgtype, body, formattedBody) {
     };
 }
 
-export function reply(entry, msgtype, body) {
+export function createReplyContent(entry, msgtype, body) {
     // TODO check for absense of sender / body / msgtype / etc?
     const nonTextual = fallbackForNonTextualMessage(entry.content.msgtype);
     const prefix = fallbackPrefix(entry.content.msgtype);
@@ -70,5 +70,5 @@ export function reply(entry, msgtype, body) {
 
     const newBody = plainFallback + '\n\n' + body;
     const newFormattedBody = formattedFallback + htmlEscape(body);
-    return createReply(entry.id, msgtype, newBody, newFormattedBody);
+    return _createReplyContent(entry.id, msgtype, newBody, newFormattedBody);
 }

--- a/src/matrix/room/timeline/entries/reply.js
+++ b/src/matrix/room/timeline/entries/reply.js
@@ -1,0 +1,33 @@
+
+export function fallbackBlurb(msgtype) {
+    switch (msgtype) {
+        case "m.file":
+            return "sent a file.";
+        case "m.image":
+            return "sent an image.";
+        case "m.video":
+            return "sent a video.";
+        case "m.audio":
+            return "sent an audio file.";
+    }
+    return null;
+}
+
+export function fallbackPrefix(msgtype) {
+    return msgtype === "m.emote" ? "* " : "";
+}
+
+export function createReply(targetId, msgtype, body, formattedBody) {
+    return {
+        msgtype,
+        body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": formattedBody,
+        "m.relates_to": {
+            "m.in_reply_to": {
+                "event_id": targetId
+            }
+        }
+    };
+}
+

--- a/src/matrix/room/timeline/persistence/RelationWriter.js
+++ b/src/matrix/room/timeline/persistence/RelationWriter.js
@@ -30,7 +30,8 @@ export class RelationWriter {
         const {relatedEventId} = sourceEntry;
         if (relatedEventId) {
             const relation = getRelation(sourceEntry.event);
-            if (relation) {
+            if (relation && relation.rel_type) {
+                // we don't consider replies (which aren't relations in the MSC2674 sense)
                 txn.timelineRelations.add(this._roomId, relation.event_id, relation.rel_type, sourceEntry.id);
             }
             const target = await txn.timelineEvents.getByEventId(this._roomId, relatedEventId);
@@ -120,7 +121,7 @@ export class RelationWriter {
         log.set("id", redactedEvent.event_id);
 
         const relation = getRelation(redactedEvent);
-        if (relation) {
+        if (relation && relation.rel_type) {
             txn.timelineRelations.remove(this._roomId, relation.event_id, relation.rel_type, redactedEvent.event_id);
         }
         // check if we're the target of a relation and remove all relations then as well

--- a/src/matrix/room/timeline/relations.js
+++ b/src/matrix/room/timeline/relations.js
@@ -29,13 +29,25 @@ export function createAnnotation(targetId, key) {
     };
 }
 
+export function getRelationTarget(relation) {
+    return relation.event_id || relation["m.in_reply_to"]?.event_id
+}
+
+export function setRelationTarget(relation, target) {
+    if (relation.event_id !== undefined) {
+        relation.event_id = target;
+    } else if (relation["m.in_reply_to"]) {
+        relation["m.in_reply_to"].event_id = target;
+    }
+}
+
 export function getRelatedEventId(event) {
 	if (event.type === REDACTION_TYPE) {
         return event.redacts;
     } else {
         const relation = getRelation(event);
         if (relation) {
-            return relation.event_id;
+            return getRelationTarget(relation);
         }
     }
     return null;

--- a/src/matrix/room/timeline/relations.js
+++ b/src/matrix/room/timeline/relations.js
@@ -29,20 +29,6 @@ export function createAnnotation(targetId, key) {
     };
 }
 
-export function createReply(targetId, msgtype, body, formattedBody) {
-    return {
-        msgtype,
-        body,
-        "format": "org.matrix.custom.html",
-        "formatted_body": formattedBody,
-        "m.relates_to": {
-            "m.in_reply_to": {
-                "event_id": targetId
-            }
-        }
-    };
-}
-
 export function getRelationTarget(relation) {
     return relation.event_id || relation["m.in_reply_to"]?.event_id
 }

--- a/src/matrix/room/timeline/relations.js
+++ b/src/matrix/room/timeline/relations.js
@@ -29,10 +29,12 @@ export function createAnnotation(targetId, key) {
     };
 }
 
-export function createReply(targetId, msgtype, body) {
+export function createReply(targetId, msgtype, body, formattedBody) {
     return {
         msgtype,
         body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": formattedBody,
         "m.relates_to": {
             "m.in_reply_to": {
                 "event_id": targetId

--- a/src/matrix/room/timeline/relations.js
+++ b/src/matrix/room/timeline/relations.js
@@ -29,10 +29,14 @@ export function createAnnotation(targetId, key) {
     };
 }
 
-export function createReply(targetId) {
+export function createReply(targetId, msgtype, body) {
     return {
-        "m.in_reply_to": {
-            "event_id": targetId
+        msgtype,
+        body,
+        "m.relates_to": {
+            "m.in_reply_to": {
+                "event_id": targetId
+            }
         }
     };
 }

--- a/src/matrix/room/timeline/relations.js
+++ b/src/matrix/room/timeline/relations.js
@@ -29,6 +29,14 @@ export function createAnnotation(targetId, key) {
     };
 }
 
+export function createReply(targetId) {
+    return {
+        "m.in_reply_to": {
+            "event_id": targetId
+        }
+    };
+}
+
 export function getRelationTarget(relation) {
     return relation.event_id || relation["m.in_reply_to"]?.event_id
 }

--- a/src/platform/web/parsehtml.js
+++ b/src/platform/web/parsehtml.js
@@ -56,6 +56,7 @@ class HTMLParseResult {
 
 const sanitizeConfig = {
     ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|xxx|mxc):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i,
+    ADD_TAGS: ['mx-reply']
 }
 
 export function parseHTML(html) {

--- a/src/platform/web/ui/css/room.css
+++ b/src/platform/web/ui/css/room.css
@@ -50,12 +50,12 @@ limitations under the License.
     margin: 0;
 }
 
-.MessageComposer {
+.MessageComposer_input {
     display: flex;
     align-items: center;
 }
 
-.MessageComposer > input {
+.MessageComposer_input > input {
     display: block;
     flex: 1;
     min-width: 0;

--- a/src/platform/web/ui/css/room.css
+++ b/src/platform/web/ui/css/room.css
@@ -50,6 +50,15 @@ limitations under the License.
     margin: 0;
 }
 
+.MessageComposer_replyPreview {
+    display: grid;
+    grid-template-columns: 1fr auto;
+}
+
+.MessageComposer_replyPreview .Timeline_message {
+    grid-column: 1/-1;
+}
+
 .MessageComposer_input {
     display: flex;
     align-items: center;

--- a/src/platform/web/ui/css/themes/bubbles/theme.css
+++ b/src/platform/web/ui/css/themes/bubbles/theme.css
@@ -118,7 +118,7 @@ a {
     color: red;
 }
 
-.MessageComposer > input {
+.MessageComposer_input > input {
     padding: 0.8em;
     border: none;
 }

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -467,8 +467,12 @@ a {
     margin-top: 5px;
 }
 
+.MessageComposer_replyPreview {
+    border: 1px solid rgba(225, 225, 225, 0.9);
+    background: rgba(245, 245, 245, 0.90);
+}
+
 .MessageComposer_input, .MessageComposer_replyPreview {
-    border-top: 1px solid rgba(245, 245, 245, 0.90);
     padding: 8px 16px;
 }
 
@@ -491,6 +495,10 @@ a {
     background-repeat: no-repeat;
     background-position: center;
     background-size: 18px;
+}
+
+.MessageComposer_input:first-child {
+    border-top: 1px solid rgba(245, 245, 245, 0.90);
 }
 
 .MessageComposer_input > :not(:first-child) {

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -462,16 +462,16 @@ a {
     color: red;
 }
 
-.MessageComposer {
+.MessageComposer_input {
     border-top: 1px solid rgba(245, 245, 245, 0.90);
     padding: 8px 16px;
 }
 
-.MessageComposer > :not(:first-child) {
+.MessageComposer_input > :not(:first-child) {
     margin-left: 12px;
 }
 
-.MessageComposer > input {
+.MessageComposer_input > input {
     padding: 0 16px;
     border: none;
     border-radius: 24px;
@@ -481,7 +481,7 @@ a {
     font-family: "Inter", sans-serif;
 }
 
-.MessageComposer > button.send {
+.MessageComposer_input > button.send {
     width: 32px;
     height: 32px;
     display: block;
@@ -496,7 +496,7 @@ a {
     background-position: center;
 }
 
-.MessageComposer > button.sendFile {
+.MessageComposer_input > button.sendFile {
     width: 32px;
     height: 32px;
     display: block;
@@ -510,7 +510,7 @@ a {
     background-position: center;
 }
 
-.MessageComposer > button.send:disabled {
+.MessageComposer_input > button.send:disabled {
     background-color: #E3E8F0;
 }
 

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -500,6 +500,7 @@ a {
     background-repeat: no-repeat;
     background-position: center;
     background-size: 18px;
+    cursor: pointer;
 }
 
 .MessageComposer_input:first-child {

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -462,9 +462,35 @@ a {
     color: red;
 }
 
-.MessageComposer_input {
+.MessageComposer_replyPreview .Timeline_message {
+    margin: 0;
+    margin-top: 5px;
+}
+
+.MessageComposer_input, .MessageComposer_replyPreview {
     border-top: 1px solid rgba(245, 245, 245, 0.90);
     padding: 8px 16px;
+}
+
+.MessageComposer_replyPreview > .replying {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.MessageComposer_replyPreview > button.cancel {
+    width: 32px;
+    height: 32px;
+    display: block;
+    border: none;
+    text-indent: 200%;
+    white-space: nowrap;
+    overflow: hidden;
+    background-color: transparent;
+    background-image: url('icons/clear.svg');
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 18px;
 }
 
 .MessageComposer_input > :not(:first-child) {

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -465,11 +465,15 @@ a {
 .MessageComposer_replyPreview .Timeline_message {
     margin: 0;
     margin-top: 5px;
+    max-height: 30vh;
+    overflow: auto;
 }
 
 .MessageComposer_replyPreview {
-    border: 1px solid rgba(225, 225, 225, 0.9);
     background: rgba(245, 245, 245, 0.90);
+    margin: 0px 10px 10px 10px;
+    box-shadow: 0px 0px 5px #91919169;
+    border-radius: 5px;
 }
 
 .MessageComposer_input, .MessageComposer_replyPreview {
@@ -480,6 +484,7 @@ a {
     display: inline-flex;
     flex-direction: row;
     align-items: center;
+    font-weight: bold;
 }
 
 .MessageComposer_replyPreview > button.cancel {

--- a/src/platform/web/ui/css/themes/element/timeline.css
+++ b/src/platform/web/ui/css/themes/element/timeline.css
@@ -51,7 +51,7 @@ limitations under the License.
     }
 }
 
-.Timeline_message:hover, .Timeline_message.selected, .Timeline_message.menuOpen {
+.Timeline_message:hover:not(.disabled), .Timeline_message.selected, .Timeline_message.menuOpen {
     background-color: rgba(141, 151, 165, 0.1);
     border-radius: 4px;
 }

--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -69,9 +69,9 @@ export class MessageComposer extends TemplateView {
         this.value.clearReplyingTo();
     }
 
-    _trySend() {
+    async _trySend() {
         this._input.focus();
-        if (this.value.sendMessage(this._input.value)) {
+        if (await this.value.sendMessage(this._input.value)) {
             this._input.value = "";
         }
     }

--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -41,7 +41,7 @@ export class MessageComposer extends TemplateView {
                     t.span('Replying'),
                     t.span({onClick: () => this._clearReplyingTo()}, 'Close'),
                     // TODO need proper view, not just assumed TextMessageView
-                    t.view(new TextMessageView(vm.replyViewModel, true))
+                    t.view(new TextMessageView(vm.replyViewModel, true, "div"))
                 ])
             ),
             this._input,

--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -37,8 +37,11 @@ export class MessageComposer extends TemplateView {
             t.div({
                 className: "MessageComposer_replyPreview"
             }, [
-                t.span('Replying'),
-                t.span({onClick: () => this._clearReplyingTo()}, 'Close'),
+                t.span({ className: "replying" }, "Replying"),
+                t.button({
+                    className: "cancel",
+                    onClick: () => this._clearReplyingTo()
+                }, "Close"),
                 // TODO need proper view, not just assumed TextMessageView
                 t.view(new TextMessageView(vm.replyViewModel, true, "div"))
             ])

--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -45,7 +45,7 @@ export class MessageComposer extends TemplateView {
                         className: "cancel",
                         onClick: () => this._clearReplyingTo()
                     }, "Close"),
-                    t.view(new View(rvm, true, "div"))
+                    t.view(new View(rvm, false, "div"))
                 ])
         });
         const input = t.div({className: "MessageComposer_input"}, [

--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -33,17 +33,17 @@ export class MessageComposer extends TemplateView {
             onKeydown: e => this._onKeyDown(e),
             onInput: () => vm.setInput(this._input.value),
         });
-        return t.div({className: "MessageComposer"}, [
-            t.map(vm => vm.replyViewModel, (rvm, t) => !rvm ? null :
-                t.div({
-                    className: "replyBox"
-                }, [
-                    t.span('Replying'),
-                    t.span({onClick: () => this._clearReplyingTo()}, 'Close'),
-                    // TODO need proper view, not just assumed TextMessageView
-                    t.view(new TextMessageView(vm.replyViewModel, true, "div"))
-                ])
-            ),
+        const replyPreview = t.map(vm => vm.replyViewModel, (rvm, t) => !rvm ? null :
+            t.div({
+                className: "MessageComposer_replyPreview"
+            }, [
+                t.span('Replying'),
+                t.span({onClick: () => this._clearReplyingTo()}, 'Close'),
+                // TODO need proper view, not just assumed TextMessageView
+                t.view(new TextMessageView(vm.replyViewModel, true, "div"))
+            ])
+        );
+        const input = t.div({className: "MessageComposer_input"}, [
             this._input,
             t.button({
                 className: "sendFile",
@@ -57,6 +57,7 @@ export class MessageComposer extends TemplateView {
                 onClick: () => this._trySend(),
             }, vm.i18n`Send`),
         ]);
+        return t.div({ className: "MessageComposer" }, [replyPreview, input]);
     }
 
     _clearReplyingTo() {

--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -17,6 +17,7 @@ limitations under the License.
 import {TemplateView} from "../../general/TemplateView.js";
 import {Popup} from "../../general/Popup.js";
 import {Menu} from "../../general/Menu.js";
+import {TextMessageView} from "./timeline/TextMessageView.js";
 
 export class MessageComposer extends TemplateView {
     constructor(viewModel) {
@@ -33,6 +34,16 @@ export class MessageComposer extends TemplateView {
             onInput: () => vm.setInput(this._input.value),
         });
         return t.div({className: "MessageComposer"}, [
+            t.map(vm => vm.replyViewModel, (rvm, t) => !rvm ? null :
+                t.div({
+                    className: "replyBox"
+                }, [
+                    t.span('Replying'),
+                    t.span({onClick: () => this._clearReplyingTo()}, 'Close'),
+                    // TODO need proper view, not just assumed TextMessageView
+                    t.view(new TextMessageView(vm.replyViewModel, true))
+                ])
+            ),
             this._input,
             t.button({
                 className: "sendFile",
@@ -46,6 +57,10 @@ export class MessageComposer extends TemplateView {
                 onClick: () => this._trySend(),
             }, vm.i18n`Send`),
         ]);
+    }
+
+    _clearReplyingTo() {
+        this.value.clearReplyingTo();
     }
 
     _trySend() {

--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -18,6 +18,7 @@ import {TemplateView} from "../../general/TemplateView.js";
 import {Popup} from "../../general/Popup.js";
 import {Menu} from "../../general/Menu.js";
 import {TextMessageView} from "./timeline/TextMessageView.js";
+import {viewClassForEntry} from "./TimelineList.js"
 
 export class MessageComposer extends TemplateView {
     constructor(viewModel) {
@@ -33,19 +34,20 @@ export class MessageComposer extends TemplateView {
             onKeydown: e => this._onKeyDown(e),
             onInput: () => vm.setInput(this._input.value),
         });
-        const replyPreview = t.map(vm => vm.replyViewModel, (rvm, t) => !rvm ? null :
-            t.div({
-                className: "MessageComposer_replyPreview"
-            }, [
-                t.span({ className: "replying" }, "Replying"),
-                t.button({
-                    className: "cancel",
-                    onClick: () => this._clearReplyingTo()
-                }, "Close"),
-                // TODO need proper view, not just assumed TextMessageView
-                t.view(new TextMessageView(vm.replyViewModel, true, "div"))
-            ])
-        );
+        const replyPreview = t.map(vm => vm.replyViewModel, (rvm, t) => {
+            const View = rvm && viewClassForEntry(rvm);
+            if (!View) { return null; }
+            return t.div({
+                    className: "MessageComposer_replyPreview"
+                }, [
+                    t.span({ className: "replying" }, "Replying"),
+                    t.button({
+                        className: "cancel",
+                        onClick: () => this._clearReplyingTo()
+                    }, "Close"),
+                    t.view(new View(rvm, true, "div"))
+                ])
+        });
         const input = t.div({className: "MessageComposer_input"}, [
             this._input,
             t.button({

--- a/src/platform/web/ui/session/room/TimelineList.js
+++ b/src/platform/web/ui/session/room/TimelineList.js
@@ -24,7 +24,7 @@ import {MissingAttachmentView} from "./timeline/MissingAttachmentView.js";
 import {AnnouncementView} from "./timeline/AnnouncementView.js";
 import {RedactedView} from "./timeline/RedactedView.js";
 
-function viewClassForEntry(entry) {
+export function viewClassForEntry(entry) {
     switch (entry.shape) {
         case "gap": return GapView;
         case "announcement": return AnnouncementView;

--- a/src/platform/web/ui/session/room/timeline/BaseMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMessageView.js
@@ -28,8 +28,7 @@ export class BaseMessageView extends TemplateView {
         super(value);
         this._menuPopup = null;
         this._tagName = tagName;
-        // TODO An enum could be nice to make code
-        //      easier to read at call sites.
+        // TODO An enum could be nice to make code easier to read at call sites.
         this._disabled = disabled;
     }
 
@@ -56,7 +55,7 @@ export class BaseMessageView extends TemplateView {
             if (isContinuation && wasContinuation === false && !this._disabled) {
                 li.removeChild(li.querySelector(".Timeline_messageAvatar"));
                 li.removeChild(li.querySelector(".Timeline_messageSender"));
-            } else if (!isContinuation || this._disabled) {
+            } else if (!isContinuation && !this._disabled) {
                 li.insertBefore(renderStaticAvatar(vm, 30, "Timeline_messageAvatar"), li.firstChild);
                 li.insertBefore(tag.div({className: `Timeline_messageSender usercolor${vm.avatarColorNumber}`}, vm.displayName), li.firstChild);
             }

--- a/src/platform/web/ui/session/room/timeline/BaseMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMessageView.js
@@ -52,10 +52,10 @@ export class BaseMessageView extends TemplateView {
         // as the avatar or sender doesn't need any bindings or event handlers.
         // don't use `t` from within the side-effect callback
         t.mapSideEffect(vm => vm.isContinuation, (isContinuation, wasContinuation) => {
-            if (isContinuation && wasContinuation === false && !this._disabled) {
+            if (isContinuation && !this._disabled && wasContinuation === false) {
                 li.removeChild(li.querySelector(".Timeline_messageAvatar"));
                 li.removeChild(li.querySelector(".Timeline_messageSender"));
-            } else if (!isContinuation && !this._disabled) {
+            } else if (!isContinuation || this._disabled) {
                 li.insertBefore(renderStaticAvatar(vm, 30, "Timeline_messageAvatar"), li.firstChild);
                 li.insertBefore(tag.div({className: `Timeline_messageSender usercolor${vm.avatarColorNumber}`}, vm.displayName), li.firstChild);
             }
@@ -64,11 +64,11 @@ export class BaseMessageView extends TemplateView {
         // but that adds a comment node to all messages without reactions
         let reactionsView = null;
         t.mapSideEffect(vm => vm.reactions, reactions => {
-            if (reactions && !reactionsView && !this._disabled) {
+            if (reactions && !this._disabled && !reactionsView) {
                 reactionsView = new ReactionsView(vm.reactions);
                 this.addSubView(reactionsView);
                 li.appendChild(mountView(reactionsView));
-            } else if (!reactions && reactionsView && !this._disabled) {
+            } else if (!reactions && reactionsView) {
                 li.removeChild(reactionsView.root());
                 reactionsView.unmount();
                 this.removeSubView(reactionsView);

--- a/src/platform/web/ui/session/room/timeline/BaseMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMessageView.js
@@ -52,10 +52,10 @@ export class BaseMessageView extends TemplateView {
         // as the avatar or sender doesn't need any bindings or event handlers.
         // don't use `t` from within the side-effect callback
         t.mapSideEffect(vm => vm.isContinuation, (isContinuation, wasContinuation) => {
-            if (isContinuation && this._interactive && wasContinuation === false) {
+            if (isContinuation && wasContinuation === false) {
                 li.removeChild(li.querySelector(".Timeline_messageAvatar"));
                 li.removeChild(li.querySelector(".Timeline_messageSender"));
-            } else if (!isContinuation || !this._interactive) {
+            } else if (!isContinuation) {
                 li.insertBefore(renderStaticAvatar(vm, 30, "Timeline_messageAvatar"), li.firstChild);
                 li.insertBefore(tag.div({className: `Timeline_messageSender usercolor${vm.avatarColorNumber}`}, vm.displayName), li.firstChild);
             }

--- a/src/platform/web/ui/session/room/timeline/BaseMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMessageView.js
@@ -113,6 +113,7 @@ export class BaseMessageView extends TemplateView {
         if (vm.canReact && vm.shape !== "redacted") {
             options.push(new QuickReactionsMenuOption(vm));
         }
+        options.push(Menu.option(vm.i18n`Reply`, () => vm.setReply()));
         if (vm.canAbortSending) {
             options.push(Menu.option(vm.i18n`Cancel`, () => vm.abortSending()));
         } else if (vm.canRedact) {

--- a/src/platform/web/ui/session/room/timeline/BaseMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMessageView.js
@@ -24,20 +24,22 @@ import {Menu} from "../../../general/Menu.js";
 import {ReactionsView} from "./ReactionsView.js";
 
 export class BaseMessageView extends TemplateView {
-    constructor(value, disabled = false) {
+    constructor(value, disabled = false, tagName = "li") {
         super(value);
         this._menuPopup = null;
+        this._tagName = tagName;
         // TODO An enum could be nice to make code
         //      easier to read at call sites.
         this._disabled = disabled;
     }
 
     render(t, vm) {
-        const li = t.li({className: {
+        const li = t.el(this._tagName, {className: {
             "Timeline_message": true,
             own: vm.isOwn,
             unsent: vm.isUnsent,
             unverified: vm.isUnverified,
+            disabled: this._disabled,
             continuation: vm => vm.isContinuation,
         }}, [
             // dynamically added and removed nodes are handled below
@@ -115,8 +117,8 @@ export class BaseMessageView extends TemplateView {
         const options = [];
         if (vm.canReact && vm.shape !== "redacted") {
             options.push(new QuickReactionsMenuOption(vm));
+            options.push(Menu.option(vm.i18n`Reply`, () => vm.startReply()));
         }
-        options.push(Menu.option(vm.i18n`Reply`, () => vm.startReply()));
         if (vm.canAbortSending) {
             options.push(Menu.option(vm.i18n`Cancel`, () => vm.abortSending()));
         } else if (vm.canRedact) {

--- a/src/platform/web/ui/session/room/timeline/BaseMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMessageView.js
@@ -113,7 +113,7 @@ export class BaseMessageView extends TemplateView {
         if (vm.canReact && vm.shape !== "redacted") {
             options.push(new QuickReactionsMenuOption(vm));
         }
-        options.push(Menu.option(vm.i18n`Reply`, () => vm.setReply()));
+        options.push(Menu.option(vm.i18n`Reply`, () => vm.startReply()));
         if (vm.canAbortSending) {
             options.push(Menu.option(vm.i18n`Cancel`, () => vm.abortSending()));
         } else if (vm.canRedact) {


### PR DESCRIPTION
Opening this primarily to keep track of what's left to be done. So far there's:

- [X] Add a reply button to messages in the timeline that puts us in reply mode
- [X] Make sure replies to pending events work (this requires expanding the code that resolves remote echo to still work with the shape of reply events, which use `m.relates_to`, but not the same way as annotations).
- [ ] Proper message formatting. From the spec:
    > Clients that do support rich replies MUST provide the fallback format on replies, and MUST strip the fallback before rendering the reply. Rich replies MUST have a format of org.matrix.custom.html and therefore a formatted_body alongside the body and appropriate msgtype.

   That's a lot of "MUST"! We don't even send HTML messages yet.
  - [x] Properly _insert_ reply fallback, in both plain `body` and `formatted_body`.
  - [x] Properly _strip_ reply fallback
  - [ ] Render replies using another mechanism.
- [x] Indicate in the UI that we're replying to a message. This may be a bit problematic since the rendering of regular message tiles is not quite what we want (hides avatars, shows replies, etc).
- [ ] Test that everything still works as intended. There are some changes to `SendQueue`, for instance.