### PR TITLE
Add rendering for horizontal rules

### DIFF
--- a/src/domain/session/room/timeline/MessageBody.js
+++ b/src/domain/session/room/timeline/MessageBody.js
@@ -74,7 +74,7 @@ export class TableBlock {
 }
 
 export class RulePart {
-    get type( ) { return "rule"; }
+    get type() { return "rule"; }
 }
 
 export class NewLinePart {

--- a/src/platform/web/ui/general/html.js
+++ b/src/platform/web/ui/general/html.js
@@ -94,7 +94,7 @@ export const TAG_NAMES = {
     [HTML_NS]: [
         "br", "a", "ol", "ul", "li", "div", "h1", "h2", "h3", "h4", "h5", "h6",
         "p", "strong", "em", "span", "img", "section", "main", "article", "aside", "del", "blockquote",
-        "table", "thead", "tbody", "tr", "th", "td",
+        "table", "thead", "tbody", "tr", "th", "td", "hr",
         "pre", "code", "button", "time", "input", "textarea", "label", "form", "progress", "output", "video"],
     [SVG_NS]: ["svg", "circle"]
 };

--- a/src/platform/web/ui/session/room/timeline/TextMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/TextMessageView.js
@@ -97,6 +97,7 @@ const formatFunction = {
     link: linkPart => tag.a({href: linkPart.url, className: "link", target: "_blank", rel: "noopener" }, renderParts(linkPart.inlines)),
     pill: renderPill,
     format: formatPart => tag[formatPart.format](renderParts(formatPart.children)),
+    rule: rulePart => tag.hr(),
     list: renderList,
     image: renderImage,
     newline: () => tag.br()


### PR DESCRIPTION
Before this PR, messages with `<hr>` tags would not be rendered and cause a crash.