### PR TITLE
Check for null keys in settings view model

### DIFF
--- a/src/domain/session/settings/SettingsViewModel.js
+++ b/src/domain/session/settings/SettingsViewModel.js
@@ -28,9 +28,6 @@ class PushNotificationStatus {
 }
 
 function formatKey(key) {
-    if (!key) {
-        return null;
-    }
     const partLength = 4;
     const partCount = Math.ceil(key.length / partLength);
     let formattedKey = "";
@@ -80,7 +77,11 @@ export class SettingsViewModel extends ViewModel {
     }
 
     get fingerprintKey() {
-        return formatKey(this._session.fingerprintKey);
+        const key = this._session.fingerprintKey;
+        if (!key) {
+            return null;
+        }
+        return formatKey(key);
     }
 
     get deviceId() {

--- a/src/domain/session/settings/SettingsViewModel.js
+++ b/src/domain/session/settings/SettingsViewModel.js
@@ -28,6 +28,9 @@ class PushNotificationStatus {
 }
 
 function formatKey(key) {
+    if (!key) {
+        return null;
+    }
     const partLength = 4;
     const partCount = Math.ceil(key.length / partLength);
     let formattedKey = "";


### PR DESCRIPTION
The keys to format in the settings view model might be null. This avoids crashing the UI by testing for this case.