### PR TITLE
improve menu on small screens

### DIFF
--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -726,6 +726,9 @@ button.link {
     list-style: none;
     margin: 0;
     width: calc(100% - 48px);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
 }
 
 .menu li{
@@ -737,7 +740,7 @@ button.link {
     border: none;
     background-color: transparent;
     text-align: left;
-    padding: 8px 32px 8px 8px;
+    padding: 8px;
     font-size: 1.5rem;
     height: 24px;
     cursor: pointer;
@@ -749,8 +752,9 @@ button.link {
 
 .menu .quick-reactions {
     display: flex;
-    padding: 8px;
+    padding: 8px 8px 0;
     flex-wrap: wrap;
+    flex-basis: 100%;
 }
 
 .menu .quick-reactions button {

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -749,6 +749,7 @@ button.link {
 .menu .quick-reactions {
     display: flex;
     padding: 8px 32px 8px 8px;
+    flex-wrap: wrap;
 }
 
 .menu .quick-reactions button {

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -725,6 +725,7 @@ button.link {
     background-color: white;
     list-style: none;
     margin: 0;
+    width: calc(100% - 48px);
 }
 
 .menu li{

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -726,9 +726,6 @@ button.link {
     list-style: none;
     margin: 0;
     width: calc(100% - 48px);
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
 }
 
 .menu li{
@@ -740,7 +737,7 @@ button.link {
     border: none;
     background-color: transparent;
     text-align: left;
-    padding: 8px;
+    padding: 8px 32px 8px 8px;
     font-size: 1.5rem;
     height: 24px;
     cursor: pointer;
@@ -752,9 +749,8 @@ button.link {
 
 .menu .quick-reactions {
     display: flex;
-    padding: 8px 8px 0;
+    padding: 8px;
     flex-wrap: wrap;
-    flex-basis: 100%;
 }
 
 .menu .quick-reactions button {

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -749,7 +749,7 @@ button.link {
 
 .menu .quick-reactions {
     display: flex;
-    padding: 8px 32px 8px 8px;
+    padding: 8px;
     flex-wrap: wrap;
 }
 


### PR DESCRIPTION
original: 
<img src="https://user-images.githubusercontent.com/476060/132210416-5f40f089-22b5-464c-8603-cf764cb500e7.jpeg" width="320" height="157"/> 

* wrap to prevent the menu from popping out of small screens:

<img src="https://user-images.githubusercontent.com/476060/132210419-6a589f4c-52fa-4065-9141-8130e5e55620.jpeg" width="320" height="157"/>

* menu distance to border equal on left and right
* reduce unused screen real estate inside the menu

<img src="https://user-images.githubusercontent.com/476060/132213997-b76304fc-7fcd-4e64-9ade-215a404273ca.jpeg" width="320" height="157"/>

* put reply and delete buttons next to each other to prevent delete button from popping out of the screen

<img src="https://user-images.githubusercontent.com/476060/132216581-d77080e4-bd34-464c-ac48-857810b7b9c3.jpeg" width="320" height="157"/>


