### PR TITLE
Fix util import

### DIFF
--- a/src/logging/IDBLogger.js
+++ b/src/logging/IDBLogger.js
@@ -21,7 +21,7 @@ import {
     reqAsPromise,
     iterateCursor,
     fetchResults,
-} from "../matrix/storage/idb/utils.js";
+} from "../matrix/storage/idb/utils";
 import {BaseLogger} from "./BaseLogger.js";
 
 export class IDBLogger extends BaseLogger {


### PR DESCRIPTION
This seems to have broken during TypeScript conversion; because `IDBLogger` is still a JS file, this wasn't picked up by `tsc`, and Snowpack is smart enough to resolve messed up imports like this. Should fix #501 