### PR TITLE
use mapped value rather than reading parent vm again

### DIFF
--- a/src/platform/web/ui/session/room/timeline/BaseMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMessageView.js
@@ -66,7 +66,7 @@ export class BaseMessageView extends TemplateView {
         let reactionsView = null;
         t.mapSideEffect(vm => vm.reactions, reactions => {
             if (reactions && this._interactive && !reactionsView) {
-                reactionsView = new ReactionsView(vm.reactions);
+                reactionsView = new ReactionsView(reactions);
                 this.addSubView(reactionsView);
                 li.appendChild(mountView(reactionsView));
             } else if (!reactions && reactionsView) {


### PR DESCRIPTION
I got this error on my phone last night, indicating the ReactionsViewModel was null in the ReactionsView. Hard to imagine how, in the binding that calls this constructor, the parent view model could switch the reactions property while the binding is being evaluated given the single-threaded nature of javascript, but that's the only thing I could come up with... :shrug: 

```
Error: TypeError TypeError: Cannot read properties of null (reading 'reactions') at new ReactionsView (https://hydrogen.element.io/hydrogen-1622763656.js:4335:38) at https://hydrogen.element.io/hydrogen-
```