### PR TITLE
don't (re)link fragments in fill, close gap if overlap w linked fragment

### DIFF
--- a/src/matrix/room/timeline/persistence/GapWriter.js
+++ b/src/matrix/room/timeline/persistence/GapWriter.js
@@ -26,8 +26,9 @@ export class GapWriter {
         this._fragmentIdComparer = fragmentIdComparer;
         this._relationWriter = relationWriter;
     }
-    // events is in reverse-chronological order (last event comes at index 0) if backwards
-    async _findOverlappingEvents(fragmentEntry, events, txn, log) {
+
+    async _findOverlappingEvents(fragmentEntry, events, txn) {
+        const eventIds = events.map(e => e.event_id);
         const existingEventKeyMap = await txn.timelineEvents.getEventKeysForIds(this._roomId, eventIds);
         const nonOverlappingEvents = events.filter(e => !existingEventKeyMap.has(e.event_id));
         let neighbourFragmentEntry;
@@ -185,7 +186,7 @@ export class GapWriter {
         const {
             nonOverlappingEvents,
             neighbourFragmentEntry
-        } = await this._findOverlappingEvents(fragmentEntry, chunk, txn, log);
+        } = await this._findOverlappingEvents(fragmentEntry, chunk, txn);
         // create entries for all events in chunk, add them to entries
         const {entries, updatedEntries} = await this._storeEvents(nonOverlappingEvents, lastKey, direction, state, txn, log);
         const fragments = await this._updateFragments(fragmentEntry, neighbourFragmentEntry, end, entries, txn);

--- a/src/matrix/room/timeline/persistence/GapWriter.js
+++ b/src/matrix/room/timeline/persistence/GapWriter.js
@@ -123,7 +123,7 @@ export class GapWriter {
         }
     }
 
-    async _updateFragments(fragmentEntry, neighbourFragmentEntry, end, entries, txn) {
+    async _updateFragments(fragmentEntry, neighbourFragmentEntry, end, entries, txn, log) {
         const {direction} = fragmentEntry;
         const changedFragments = [];
         directionalAppend(entries, fragmentEntry, direction);
@@ -131,6 +131,7 @@ export class GapWriter {
         if (neighbourFragmentEntry) {
             // if neighbourFragmentEntry was found, it means the events were overlapping,
             // so no pagination should happen anymore.
+            log.set("closedGapWith", neighbourFragmentEntry.fragmentId);
             neighbourFragmentEntry.token = null;
             fragmentEntry.token = null;
 
@@ -189,7 +190,7 @@ export class GapWriter {
         } = await this._findOverlappingEvents(fragmentEntry, chunk, txn);
         // create entries for all events in chunk, add them to entries
         const {entries, updatedEntries} = await this._storeEvents(nonOverlappingEvents, lastKey, direction, state, txn, log);
-        const fragments = await this._updateFragments(fragmentEntry, neighbourFragmentEntry, end, entries, txn);
+        const fragments = await this._updateFragments(fragmentEntry, neighbourFragmentEntry, end, entries, txn, log);
     
         return {entries, updatedEntries, fragments};
     }

--- a/src/matrix/storage/idb/stores/TimelineEventStore.ts
+++ b/src/matrix/storage/idb/stores/TimelineEventStore.ts
@@ -44,6 +44,11 @@ function encodeKey(roomId: string, fragmentId: number, eventIndex: number): stri
     return `${roomId}|${encodeUint32(fragmentId)}|${encodeUint32(eventIndex)}`;
 }
 
+function decodeKey(key: string): { roomId: string, fragmentId: number, eventIndex: number } {
+    const [roomId, fragmentId, eventIndex] = key.split("|");
+    return {roomId, fragmentId: parseInt(fragmentId, 10), eventIndex: parseInt(eventIndex, 10)};
+}
+
 function encodeEventIdKey(roomId: string, eventId: string): string {
     return `${roomId}|${eventId}`;
 }
@@ -218,6 +223,19 @@ export class TimelineEventStore {
         const events = await this._timelineStore.selectLimitReverse(range, amount);
         events.reverse(); // because we fetched them backwards
         return events;
+    }
+
+    async getEventKeysForIds(roomId: string, eventIds: string[]): Promise<Map<string, EventKey>> {
+        const byEventId = this._timelineStore.index("byEventId");
+        const keys = eventIds.map(eventId => encodeEventIdKey(roomId, eventId));
+        const results = new Map();
+        await byEventId.findExistingKeys(keys, false, (indexKey, pk) => {
+            const {eventId} = decodeEventIdKey(indexKey as string);
+            const {fragmentId, eventIndex} = decodeKey(pk as string);
+            results.set(eventId, new EventKey(fragmentId, eventIndex));
+            return false;
+        });
+        return results;
     }
 
     /** Finds the first eventId that occurs in the store, if any.

--- a/src/matrix/storage/idb/stores/TimelineEventStore.ts
+++ b/src/matrix/storage/idb/stores/TimelineEventStore.ts
@@ -44,9 +44,9 @@ function encodeKey(roomId: string, fragmentId: number, eventIndex: number): stri
     return `${roomId}|${encodeUint32(fragmentId)}|${encodeUint32(eventIndex)}`;
 }
 
-function decodeKey(key: string): { roomId: string, fragmentId: number, eventIndex: number } {
+function decodeKey(key: string): { roomId: string, eventKey: EventKey } {
     const [roomId, fragmentId, eventIndex] = key.split("|");
-    return {roomId, fragmentId: parseInt(fragmentId, 10), eventIndex: parseInt(eventIndex, 10)};
+    return {roomId, eventKey: new EventKey(parseInt(fragmentId, 10), parseInt(eventIndex, 10))};
 }
 
 function encodeEventIdKey(roomId: string, eventId: string): string {
@@ -231,8 +231,8 @@ export class TimelineEventStore {
         const results = new Map();
         await byEventId.findExistingKeys(keys, false, (indexKey, pk) => {
             const {eventId} = decodeEventIdKey(indexKey as string);
-            const {fragmentId, eventIndex} = decodeKey(pk as string);
-            results.set(eventId, new EventKey(fragmentId, eventIndex));
+            const {eventKey} = decodeKey(pk as string);
+            results.set(eventId, eventKey);
             return false;
         });
         return results;


### PR DESCRIPTION
Fixes #393, alternative to #505 

Having reached the conclusion that we might not be able to determine overlap when storing /context responses in the timeline event store, this PR assumes all fragments are sync fragments and don't need to be linked up when backfilling. Thus the solution to find overlap becomes simpler and we close the gap when at least one event with the expected fragment id is found in the /messages response.