### PR TITLE
move over word-break lines

### DIFF
--- a/src/platform/web/ui/css/themes/element/timeline.css
+++ b/src/platform/web/ui/css/themes/element/timeline.css
@@ -90,6 +90,9 @@ limitations under the License.
 .Timeline_messageSender, .Timeline_messageBody {
     /* reset body margin */
     margin: 0;
+    /* first try break-all, then break-word, which isn't supported everywhere */
+    word-break: break-all;  
+    word-break: break-word;
 }
 
 .Timeline_message:not(.continuation) .Timeline_messageSender,

--- a/src/platform/web/ui/css/timeline.css
+++ b/src/platform/web/ui/css/timeline.css
@@ -47,26 +47,6 @@ limitations under the License.
     margin: 0;
 }
 
-.message-container {
-    flex: 0 1 auto;
-    /* first try break-all, then break-word, which isn't supported everywhere */
-    word-break: break-all;  
-    word-break: break-word;
-}
-
-.message-container .sender {
-    margin: 5px 0;
-}
-
-.message-container .media {
-    display: block;
-}
-
-.message-container .media > img,
-.message-container .media > video {
-    display: block;
-}
-
 .AnnouncementView {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Fixes #499 

this didn't get moved over when converting the timeline tile css to css grid

