### PR TITLE
Make progress bar work for image uploads in Chrome

### DIFF
--- a/src/platform/web/dom/request/xhr.js
+++ b/src/platform/web/dom/request/xhr.js
@@ -37,6 +37,11 @@ class RequestResult {
 
 function createXhr(url, {method, headers, timeout, format, uploadProgress}) {
     const xhr = new XMLHttpRequest();
+
+    if (uploadProgress) {
+        xhr.upload.addEventListener("progress", evt => uploadProgress(evt.loaded));
+    }
+
     xhr.open(method, url);
     
     if (format === "buffer") {
@@ -54,10 +59,6 @@ function createXhr(url, {method, headers, timeout, format, uploadProgress}) {
     }
     if (timeout) {
         xhr.timeout = timeout;
-    }
-
-    if (uploadProgress) {
-        xhr.upload.addEventListener("progress", evt => uploadProgress(evt.loaded));
     }
 
     return xhr;


### PR DESCRIPTION
Fixes #570 

[MDN](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#monitoring_progress) says:
>Note: You need to add the event listeners before calling open() on the request. Otherwise the progress events will not fire. 

and they [elaborate](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/upload):
>Note: The spec also seems to indicate that event listeners should be attached after open(). However, browsers are buggy on this matter, and often need the listeners to be registered before open() to work.