### PR TITLE
Threading fallback - PR 1 - Link events with their related event

### DIFF
--- a/src/domain/session/room/timeline/ReactionsViewModel.js
+++ b/src/domain/session/room/timeline/ReactionsViewModel.js
@@ -260,9 +260,7 @@ export function tests() {
                 fragmentIdComparer,
                 clock: new MockClock(),
                 pendingEvents: queue.pendingEvents,
-                powerLevelsObservable,
-                fetchEventFromHomeserver: () => {},
-                fetchEventFromStorage: () => {}
+                powerLevelsObservable
             });
             // 3. load the timeline, which will load the message with the reaction
             await timeline.load(new User(alice), "join", new NullLogItem());

--- a/src/domain/session/room/timeline/ReactionsViewModel.js
+++ b/src/domain/session/room/timeline/ReactionsViewModel.js
@@ -254,8 +254,16 @@ export function tests() {
             // 2. setup queue & timeline
             const queue = new SendQueue({roomId, storage, hsApi: new MockHomeServer().api});
             const powerLevelsObservable = new ObservableValue(new PowerLevels({ ownUserId: alice, membership: "join" }));
-            const timeline = new Timeline({roomId, storage, fragmentIdComparer,
-                clock: new MockClock(), pendingEvents: queue.pendingEvents, powerLevelsObservable});
+            const timeline = new Timeline({
+                roomId,
+                storage,
+                fragmentIdComparer,
+                clock: new MockClock(),
+                pendingEvents: queue.pendingEvents,
+                powerLevelsObservable,
+                fetchEventFromHomeserver: () => {},
+                fetchEventFromStorage: () => {}
+            });
             // 3. load the timeline, which will load the message with the reaction
             await timeline.load(new User(alice), "join", new NullLogItem());
             const tiles = mapMessageEntriesToBaseMessageTile(timeline, queue);

--- a/src/matrix/net/HomeServerApi.ts
+++ b/src/matrix/net/HomeServerApi.ts
@@ -128,8 +128,8 @@ export class HomeServerApi {
         return this._get("/sync", {since, timeout, filter}, undefined, options);
     }
 
-    event(roomId, eventId) {
-        return this._get(`/rooms/${encodeURIComponent(roomId)}/event/${encodeURIComponent(eventId)}`);
+    context(roomId: string, eventId: string, limit: number, filter: string): IHomeServerRequest {
+        return this._get(`/rooms/${encodeURIComponent(roomId)}/context/${encodeURIComponent(eventId)}`, {filter, limit});
     }
 
     // params is from, dir and optionally to, limit, filter.

--- a/src/matrix/net/HomeServerApi.ts
+++ b/src/matrix/net/HomeServerApi.ts
@@ -128,6 +128,10 @@ export class HomeServerApi {
         return this._get("/sync", {since, timeout, filter}, undefined, options);
     }
 
+    event(roomId, eventId) {
+        return this._get(`/rooms/${encodeURIComponent(roomId)}/event/${encodeURIComponent(eventId)}`);
+    }
+
     // params is from, dir and optionally to, limit, filter.
     messages(roomId: string, params: Record<string, any>, options?: IRequestOptions): IHomeServerRequest {
         return this._get(`/rooms/${encodeURIComponent(roomId)}/messages`, params, undefined, options);

--- a/src/matrix/room/BaseRoom.js
+++ b/src/matrix/room/BaseRoom.js
@@ -501,7 +501,9 @@ export class BaseRoom extends EventEmitter {
                 },
                 clock: this._platform.clock,
                 logger: this._platform.logger,
-                powerLevelsObservable: await this.observePowerLevels()
+                powerLevelsObservable: await this.observePowerLevels(),
+                fetchEventFromStorage: eventId => this._readEventById(eventId),
+                fetchEventFromHomeserver: eventId => this._getEventFromHomeserver(eventId)
             });
             try {
                 if (this._roomEncryption) {
@@ -557,6 +559,12 @@ export class BaseRoom extends EventEmitter {
             }
             return entry;
         }
+    }
+
+    async _getEventFromHomeserver(eventId) {
+        const response = await this._hsApi.event(this._roomId, eventId).response();
+        const entry = new EventEntry({ event: response }, this._fragmentIdComparer);
+        return entry;
     }
 
 

--- a/src/matrix/room/BaseRoom.js
+++ b/src/matrix/room/BaseRoom.js
@@ -571,7 +571,12 @@ export class BaseRoom extends EventEmitter {
             displayName: member.content.displayname,
             avatarUrl: member.content.avatar_url
         };
-        return new NonPersistedEventEntry(entry, this._fragmentIdComparer);
+        const eventEntry = new NonPersistedEventEntry(entry, this._fragmentIdComparer);
+        if (eventEntry.eventType === EVENT_ENCRYPTED_TYPE) {
+            const request = this._decryptEntries(DecryptionSource.Timeline, [eventEntry]);
+            await request.complete();
+        }
+        return eventEntry;
     }
 
 

--- a/src/matrix/room/BaseRoom.js
+++ b/src/matrix/room/BaseRoom.js
@@ -562,9 +562,15 @@ export class BaseRoom extends EventEmitter {
     }
 
     async _getEventFromHomeserver(eventId) {
-        const response = await this._hsApi.event(this._roomId, eventId).response();
-        const entry = new EventEntry({ event: response }, this._fragmentIdComparer);
-        return entry;
+        const response = await this._hsApi.context(this._roomId, eventId, 0).response();
+        const sender = response.event.sender;
+        const member = response.state.find(e => e.type === "m.room.member" && e.user_id === sender);
+        const entry = {
+            event: response.event,
+            displayName: member.content.displayname,
+            avatarUrl: member.content.avatar_url
+        };
+        return new EventEntry(entry, this._fragmentIdComparer);
     }
 
 

--- a/src/matrix/room/BaseRoom.js
+++ b/src/matrix/room/BaseRoom.js
@@ -30,6 +30,7 @@ import {DecryptionSource} from "../e2ee/common.js";
 import {ensureLogItem} from "../../logging/utils";
 import {PowerLevels} from "./PowerLevels.js";
 import {RetainedObservableValue} from "../../observable/ObservableValue";
+import {NonPersistedEventEntry} from "./timeline/entries/NonPersistedEventEntry";
 
 const EVENT_ENCRYPTED_TYPE = "m.room.encrypted";
 
@@ -570,7 +571,7 @@ export class BaseRoom extends EventEmitter {
             displayName: member.content.displayname,
             avatarUrl: member.content.avatar_url
         };
-        return new EventEntry(entry, this._fragmentIdComparer);
+        return new NonPersistedEventEntry(entry, this._fragmentIdComparer);
     }
 
 

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -280,6 +280,7 @@ export class Timeline {
             if (fetchedEntry) {
                 fetchedEntry.contextForEntries.forEach(e => e.setContextEntry(entry));
                 entry.updateFrom(fetchedEntry);
+                this._contextEntriesNotInTimeline.delete(entry.id);
             }
         }
     }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -223,7 +223,7 @@ export class Timeline {
     /** @package */
     replaceEntries(entries) {
         this._addLocalRelationsToNewRemoteEntries(entries);
-        this._updateFetchedEntries(entries);
+        this._updateEntriesNotInTimeline(entries);
         this._loadRelatedEvents(entries);
         for (const entry of entries) {
             try {
@@ -250,18 +250,18 @@ export class Timeline {
     /** @package */
     addEntries(newEntries) {
         this._addLocalRelationsToNewRemoteEntries(newEntries);
-        this._updateFetchedEntries(newEntries);
-        this._moveFetchedEntryToRemoteEntries(newEntries);
+        this._updateEntriesNotInTimeline(newEntries);
+        this._moveEntryToRemoteEntries(newEntries);
         this._remoteEntries.setManySorted(newEntries);
         this._loadRelatedEvents(newEntries);
     }
 
     /**
      * Update entries based on newly received events.
-     * eg: a newly received redacted event may mark an existing event in contextEntriesNotInTimeline as being redacted 
+     * eg: a newly received redaction event may mark an existing event in contextEntriesNotInTimeline as being redacted
      * This is only for the events that are not in the timeline but had to fetched from elsewhere to render reply previews.
      */
-    _updateFetchedEntries(entries) {
+    _updateEntriesNotInTimeline(entries) {
         for (const entry of entries) {
             const relatedEntry = this._contextEntriesNotInTimeline.get(entry.relatedEventId);
             if (!relatedEntry) {
@@ -292,7 +292,7 @@ export class Timeline {
      * If an event we had to fetch from hs/storage is now in the timeline (for eg, due to gap fill),
      * remove the event from _contextEntriesNotInTimeline since it is now in remoteEntries
      */
-    _moveFetchedEntryToRemoteEntries(entries) {
+    _moveEntryToRemoteEntries(entries) {
         for (const entry of entries) {
             const fetchedEntry = this._contextEntriesNotInTimeline.get(entry.id);
             if (fetchedEntry) {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -271,7 +271,6 @@ export class Timeline {
             const newEntry = this._createEntryFromRelatedEntries(entry, relatedEntry);
             if (newEntry) {
                 Timeline._entryUpdater(relatedEntry, newEntry);
-                this._contextEntriesNotInTimeline.delete(relatedEntry.id);
                 this._contextEntriesNotInTimeline.set(newEntry.id, newEntry);
                 relatedEntry.contextForEntries?.forEach(e => {
                     this._remoteEntries.findAndUpdate(te => te.id === e.id, () => { return { reply: newEntry }; });

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -267,11 +267,11 @@ export class Timeline {
             if (!relatedEntry) {
                 continue;
             }
-            // update dependents with this new entry indicating that this is an update to contextEntry
             const newEntry = this._createEntryFromRelatedEntries(entry, relatedEntry);
             if (newEntry) {
                 Timeline._entryUpdater(relatedEntry, newEntry);
                 this._contextEntriesNotInTimeline.set(newEntry.id, newEntry);
+                // update other entries for which this entry is a context entry
                 relatedEntry.contextForEntries?.forEach(e => {
                     this._remoteEntries.findAndUpdate(te => te.id === e.id, () => { return { reply: newEntry }; });
                 });

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -271,6 +271,8 @@ export class Timeline {
             const newEntry = this._createEntryFromRelatedEntries(entry, relatedEntry);
             if (newEntry) {
                 Timeline._entryUpdater(relatedEntry, newEntry);
+                this._contextEntriesNotInTimeline.delete(relatedEntry.id);
+                this._contextEntriesNotInTimeline.set(newEntry.id, newEntry);
                 relatedEntry.contextForEntries?.forEach(e => {
                     this._remoteEntries.findAndUpdate(te => te.id === e.id, () => { return { reply: newEntry }; });
                 });
@@ -828,8 +830,8 @@ export function tests() {
             const entryB = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_2", bob)) });
             const entryC = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_3", bob)) });
             await timeline.load(new User(alice), "join", new NullLogItem());
-            // timeline._getEventFromStorage = () => entryA;
-            await timeline.addEntries([entryA, entryB, entryC]);
+            timeline._getEventFromStorage = () => entryA;
+            await timeline.addEntries([entryB, entryC]);
             const bin = [entryB, entryC];
             timeline.entries.subscribe({
                 onUpdate: (index) => {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -124,7 +124,7 @@ export class Timeline {
             pendingEvent: pe, member: this._ownMember,
             clock: this._clock, redactingEntry
         });
-        this._applyAndEmitLocalRelationChange(pee, target => target.addLocalRelation(pee));
+        this._applyAndEmitLocalRelationChange(pee, target => target.addRelation(pee));
         return pee;
     }
 
@@ -203,12 +203,12 @@ export class Timeline {
             if (pee.relatedEventId) {
                 const relationTarget = entries.find(e => e.id === pee.relatedEventId);
                 // no need to emit here as this entry is about to be added
-                relationTarget?.addLocalRelation(pee);
+                relationTarget?.addRelation(pee);
             }
             if (pee.redactingEntry) {
                 const eventId = pee.redactingEntry.relatedEventId;
                 const relationTarget = entries.find(e => e.id === eventId);
-                relationTarget?.addLocalRelation(pee);
+                relationTarget?.addRelation(pee);
             }
         }
     }
@@ -272,7 +272,7 @@ export class Timeline {
          */
         for (const entry of entries) {
             const relatedEntry = this._contextEntriesNotInTimeline.get(entry.relatedEventId);
-            if (relatedEntry?.addLocalRelation(entry)) {
+            if (relatedEntry?.addRelation(entry)) {
                 // update other entries for which this entry is a context entry
                 relatedEntry.contextForEntries?.forEach(e => {
                     this._remoteEntries.findAndUpdate(te => te.id === e.id, () => { return { reply: relatedEntry }; });

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -329,8 +329,13 @@ export class Timeline {
         }
     }
 
-    _getTrackedEntry(id) {
-        return this.getByEventId(id) ?? this._contextEntriesNotInTimeline.get(id);
+    /**
+     * Fetches an entry with the given event-id from remoteEntries or contextEntriesNotInTimeline.
+     * @param {string} eventId event-id of the entry
+     * @returns entry if found, undefined otherwise
+     */
+    _getTrackedEntry(eventId) {
+        return this.getByEventId(eventId) ?? this._contextEntriesNotInTimeline.get(eventId);
     }
 
     async _getEventFromStorage(eventId) {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -230,8 +230,8 @@ export class Timeline {
                 const oldEntry = this._contextEntriesNotInTimeline.get(entry.id)
                 if (oldEntry) {
                     Timeline._entryUpdater(oldEntry, entry);
+                    this._contextEntriesNotInTimeline.set(entry.id, entry);
                 }
-                this._contextEntriesNotInTimeline.set(entry.id, entry);
                 // Since this entry changed, all dependent entries should be updated
                 entry.contextForEntries?.forEach(e => this._updateEntry(e));
             } catch (err) {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -267,7 +267,7 @@ export class Timeline {
     _updateEntriesFetchedFromHomeserver(entries) {
         for (const entry of entries) {
             const relatedEntry = this._contextEntriesNotInTimeline.get(entry.relatedEventId);
-            if (!relatedEntry || !relatedEntry.isNonPersisted) {
+            if (!relatedEntry) {
                 /**
                  * Updates for entries in timeline is handled by remoteEntries observable collection
                  * Updates for entries not in timeline but fetched from storage is handled in this.replaceEntries()
@@ -294,7 +294,7 @@ export class Timeline {
      * @returns a new entry or undefined
      */
     _createEntryFromRelatedEntries(entry, relatedEntry) {
-        if (entry.isRedaction) {
+        if (entry.isRedaction && relatedEntry.isNonPersisted) {
             const newEntry = relatedEntry.clone();
             newEntry.redact(entry);
             return newEntry;

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -80,7 +80,7 @@ export class Timeline {
         const readerRequest = this._disposables.track(this._timelineReader.readFromEnd(20, txn, log));
         try {
             const entries = await readerRequest.complete();
-            await this._loadRelatedEvents(entries);
+            this._loadRelatedEvents(entries);
             this._setupEntries(entries);
         } finally {
             this._disposables.disposeTracked(readerRequest);
@@ -214,9 +214,9 @@ export class Timeline {
     }
 
     /** @package */
-    async replaceEntries(entries) {
+    replaceEntries(entries) {
         this._addLocalRelationsToNewRemoteEntries(entries);
-        await this._loadRelatedEvents(entries);
+        this._loadRelatedEvents(entries);
         for (const entry of entries) {
             try {
                 this._remoteEntries.getAndUpdate(entry, Timeline._entryUpdater);
@@ -238,9 +238,9 @@ export class Timeline {
     }
 
     /** @package */
-    async addEntries(newEntries) {
+    addEntries(newEntries) {
         this._addLocalRelationsToNewRemoteEntries(newEntries);
-        await this._loadRelatedEvents(newEntries);
+        this._loadRelatedEvents(newEntries);
         this._remoteEntries.setManySorted(newEntries);
     }
 
@@ -261,6 +261,8 @@ export class Timeline {
             }
             if (contextEvent) {
                 entry.setContextEntry(contextEvent);
+                // emit this change
+                this._remoteEntries.update(entry);
             }
         }
     }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -281,7 +281,7 @@ export class Timeline {
             if (contextEvent) {
                 if (needToTrack) {
                     // this entry was created from storage/hs, so it's not tracked by remoteEntries
-                    // we track them here for redactions
+                    // we track them here so that we can update reply preview of dependents on redaction
                     this._fetchedEventEntries.push(contextEvent);
                 }
                 contextEvent.addDependent(entry);

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -859,11 +859,11 @@ export function tests() {
             const entryB = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
             const entryC = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_3", bob)), eventIndex: 3 });
             await timeline.load(new User(alice), "join", new NullLogItem());
-            const bin = [entryB, entryC];
+            const bin = [];
             timeline.entries.subscribe({
                 onUpdate: (index) => {
-                    const i = bin.findIndex(e => e.id === index);
-                    bin.splice(i, 1);
+                    const e = timeline.remoteEntries[index];
+                    bin.push(e.id);
                 },
                 onAdd: () => null,
             });
@@ -871,7 +871,8 @@ export function tests() {
             await poll(() => timeline._remoteEntries.array.length === 2 && timeline._contextEntriesNotInTimeline.get("event_id_1"));
             const redactingEntry = new EventEntry({ event: withRedacts("event_id_1", "foo", createEvent("m.room.redaction", "event_id_3", alice)) });
             timeline.addEntries([redactingEntry]);
-            assert.strictEqual(bin.length, 0);
+            assert.strictEqual(bin.includes("event_id_2"), true);
+            assert.strictEqual(bin.includes("event_id_3"), true);
         },
 
         "context entries fetched from storage/hs are moved to remoteEntries": async assert => {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -262,7 +262,9 @@ export class Timeline {
 
     /**
      * Update entries based on newly received events.
-     * This is specific to events that are not in the timeline but had to be fetched from the homeserver.
+     * This is specific to events that are not in the timeline but had to be fetched from the homeserver
+     * because they are context-events for other events in the timeline (i.e fetched from hs so that we
+     * can render things like reply previews)
      */
     _updateEntriesFetchedFromHomeserver(entries) {
         /**

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -214,8 +214,8 @@ export class Timeline {
 
     // used in replaceEntries
     static _entryUpdater(existingEntry, entry) {
-        // ensure dependents point to the new entry instead of existingEntry
-        existingEntry.dependents?.forEach(event => event.setContextEntry(entry));
+        // ensure other entries for which this existingEntry is a context point to the new entry instead of existingEntry
+        existingEntry.contextForEntries?.forEach(event => event.setContextEntry(entry));
         entry.updateFrom(existingEntry);
         return entry;
     }
@@ -229,7 +229,7 @@ export class Timeline {
             try {
                 this._remoteEntries.getAndUpdate(entry, Timeline._entryUpdater);
                 // Since this entry changed, all dependent entries should be updated
-                entry.dependents?.forEach(e => this._updateEntry(e));
+                entry.contextForEntries?.forEach(e => this._updateEntry(e));
             } catch (err) {
                 if (err.name === "CompareError") {
                     // see FragmentIdComparer, if the replacing entry is on a fragment
@@ -262,7 +262,7 @@ export class Timeline {
             const relatedEntry = this._fetchedEventEntries.get(entry.relatedEventId);
             // todo: can this be called .addRelation instead?
             if (relatedEntry?.addLocalRelation(entry)) {
-                relatedEntry.dependents.forEach(e => this._updateEntry(e));
+                relatedEntry.contextForEntries.forEach(e => this._updateEntry(e));
             }
         }
     }
@@ -272,7 +272,7 @@ export class Timeline {
         for (const entry of entries) {
             const fetchedEntry = this._fetchedEventEntries.get(entry.id);
             if (fetchedEntry) {
-                fetchedEntry.dependents.forEach(e => e.setContextEntry(entry));
+                fetchedEntry.contextForEntries.forEach(e => e.setContextEntry(entry));
                 entry.updateFrom(fetchedEntry);
             }
         }
@@ -296,7 +296,7 @@ export class Timeline {
                 this._fetchedEventEntries.set(id, contextEvent);
             }
             if (contextEvent) {
-                contextEvent.addDependent(entry);
+                contextEvent.setAsContextOf(entry);
                 entry.setContextEntry(contextEvent);
                 // emit this change
                 this._updateEntry(entry);

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -141,7 +141,7 @@ export class Timeline {
             // redactingEntry might be a PendingEventEntry or an EventEntry, so don't assume pendingEvent
             const relatedTxnId = pee.redactingEntry.pendingEvent?.relatedTxnId;
             this._findAndUpdateEntryById(relatedTxnId, pee.redactingEntry.relatedEventId, updateOrFalse);
-            pee.redactingEntry.contextForEntries?.forEach(e => this._emitUpdateForEntry(e));
+            pee.redactingEntry.contextForEntries?.forEach(e => this._emitUpdateForEntry(e, "contextEntry"));
         }
     }
 
@@ -235,7 +235,7 @@ export class Timeline {
                     this._contextEntriesNotInTimeline.set(entry.id, entry);
                 }
                 // Since this entry changed, all dependent entries should be updated
-                entry.contextForEntries?.forEach(e => this._emitUpdateForEntry(e));
+                entry.contextForEntries?.forEach(e => this._emitUpdateForEntry(e, "contextEntry"));
             } catch (err) {
                 if (err.name === "CompareError") {
                     // see FragmentIdComparer, if the replacing entry is on a fragment
@@ -295,17 +295,17 @@ export class Timeline {
             if (fetchedEntry) {
                 fetchedEntry.contextForEntries.forEach(e => {
                     e.setContextEntry(entry);
-                    this._emitUpdateForEntry(e);
+                    this._emitUpdateForEntry(e, "contextEntry");
                 });
                 this._contextEntriesNotInTimeline.delete(entry.id);
             }
         }
     }
 
-    _emitUpdateForEntry(entry) {
+    _emitUpdateForEntry(entry, param) {
         const txnId = entry.isPending ? entry.id : null;
         const eventId = entry.isPending ? null : entry.id;
-        this._findAndUpdateEntryById(txnId, eventId, () => true);
+        this._findAndUpdateEntryById(txnId, eventId, () => param);
     }
 
     /**
@@ -333,7 +333,7 @@ export class Timeline {
             }
             if (contextEvent) {
                 entry.setContextEntry(contextEvent);
-                this._emitUpdateForEntry(entry);
+                this._emitUpdateForEntry(entry, "contextEntry");
             }
         }
     }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -463,7 +463,7 @@ import {poll} from "../../../mocks/poll.js";
 import {Clock as MockClock} from "../../../mocks/Clock.js";
 import {createMockStorage} from "../../../mocks/Storage";
 import {ListObserver} from "../../../mocks/ListObserver.js";
-import {createEvent, withTextBody, withContent, withSender, withRedacts} from "../../../mocks/event.js";
+import {createEvent, withTextBody, withContent, withSender, withRedacts, withReply} from "../../../mocks/event.js";
 import {NullLogItem} from "../../../logging/NullLogger";
 import {EventEntry} from "./entries/EventEntry.js";
 import {User} from "../../User.js";
@@ -740,16 +740,7 @@ export function tests() {
             const timeline = new Timeline({roomId, storage: await createMockStorage(), closeCallback: () => {},
                 fragmentIdComparer, pendingEvents: new ObservableArray(), clock: new MockClock()});
             const entryA = new EventEntry({ event: withTextBody("foo", createEvent("m.room.message", "event_id_1", alice)) });
-            let event = withContent({
-                body: "bar",
-                msgtype: "m.text",
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "event_id_1"
-                    }
-                }
-            }, createEvent("m.room.message", "event_id_2", bob));
-            const entryB = new EventEntry({ event });
+            const entryB = new EventEntry({ event: withReply("event_id_1", createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
             await timeline.load(new User(alice), "join", new NullLogItem());
             timeline.entries.subscribe({ onAdd: () => null, });
             timeline.addEntries([entryA, entryB]);
@@ -763,16 +754,7 @@ export function tests() {
             await txn.complete();
             const timeline = new Timeline({roomId, storage, closeCallback: () => {},
                 fragmentIdComparer, pendingEvents: new ObservableArray(), clock: new MockClock()});
-            let event = withContent({
-                body: "bar",
-                msgtype: "m.text",
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "event_id_1"
-                    }
-                }
-            }, createEvent("m.room.message", "event_id_2", bob));
-            const entryB = new EventEntry({ event, eventIndex: 2 });
+            const entryB = new EventEntry({ event: withReply("event_id_1", createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
             await timeline.load(new User(alice), "join", new NullLogItem());
             timeline.entries.subscribe({ onAdd: () => null, onUpdate: () => null });
             timeline.addEntries([entryB]);
@@ -783,16 +765,7 @@ export function tests() {
         "context entry is fetched from hs": async assert => {
             const timeline = new Timeline({roomId, storage: await createMockStorage(), closeCallback: () => {},
                 fragmentIdComparer, pendingEvents: new ObservableArray(), clock: new MockClock(), hsApi});
-            let event = withContent({
-                body: "bar",
-                msgtype: "m.text",
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "event_id_1"
-                    }
-                }
-            }, createEvent("m.room.message", "event_id_2", bob));
-            const entryB = new EventEntry({ event, eventIndex: 2 });
+            const entryB = new EventEntry({ event: withReply("event_id_1", createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
             await timeline.load(new User(alice), "join", new NullLogItem());
             timeline.entries.subscribe({ onAdd: () => null, onUpdate: () => null });
             timeline.addEntries([entryB]);
@@ -804,17 +777,8 @@ export function tests() {
             const timeline = new Timeline({roomId, storage: await createMockStorage(), closeCallback: () => {},
                 fragmentIdComparer, pendingEvents: new ObservableArray(), clock: new MockClock()});
             const entryA = new EventEntry({ event: withTextBody("foo", createEvent("m.room.message", "event_id_1", alice)), eventIndex: 1 });
-            const content = {
-                body: "bar",
-                msgtype: "m.text",
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "event_id_1"
-                    }
-                }
-            };
-            const entryB = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
-            const entryC = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_3", bob)), eventIndex: 3 });
+            const entryB = new EventEntry({ event: withReply("event_id_1", createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
+            const entryC = new EventEntry({ event: withReply("event_id_1", createEvent("m.room.message", "event_id_3", bob)), eventIndex: 3 });
             await timeline.load(new User(alice), "join", new NullLogItem());
             timeline.entries.subscribe({ onAdd: () => null, onUpdate: () => null });
             timeline.addEntries([entryA, entryB, entryC]);
@@ -825,16 +789,7 @@ export function tests() {
         "context entry in contextEntryNotInTimeline gets updated based on incoming redaction": async assert => {
             const timeline = new Timeline({roomId, storage: await createMockStorage(), closeCallback: () => {},
                 fragmentIdComparer, pendingEvents: new ObservableArray(), clock: new MockClock(), hsApi});
-            let event = withContent({
-                body: "bar",
-                msgtype: "m.text",
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "event_id_1"
-                    }
-                }
-            }, createEvent("m.room.message", "event_id_2", bob));
-            const entryB = new EventEntry({ event, eventIndex: 2 });
+            const entryB = new EventEntry({ event: withReply("event_id_1", createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
             await timeline.load(new User(alice), "join", new NullLogItem());
             timeline.entries.subscribe({ onAdd: () => null, onUpdate: () => null });
             timeline.addEntries([entryB]);
@@ -847,17 +802,8 @@ export function tests() {
         "redaction of context entry triggers updates in other entries": async assert => {
             const timeline = new Timeline({roomId, storage: await createMockStorage(), closeCallback: () => {},
                 fragmentIdComparer, pendingEvents: new ObservableArray(), clock: new MockClock(), hsApi});
-            const content = {
-                body: "bar",
-                msgtype: "m.text",
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "event_id_1"
-                    }
-                }
-            };
-            const entryB = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
-            const entryC = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_3", bob)), eventIndex: 3 });
+            const entryB = new EventEntry({ event: withReply("event_id_1", createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
+            const entryC = new EventEntry({ event: withReply("event_id_1", createEvent("m.room.message", "event_id_3", bob)), eventIndex: 3 });
             await timeline.load(new User(alice), "join", new NullLogItem());
             const bin = [];
             timeline.entries.subscribe({
@@ -879,16 +825,7 @@ export function tests() {
             const timeline = new Timeline({roomId, storage: await createMockStorage(), closeCallback: () => {},
                 fragmentIdComparer, pendingEvents: new ObservableArray(), clock: new MockClock(), hsApi});
             const entryA = new EventEntry({ event: withTextBody("foo", createEvent("m.room.message", "event_id_1", alice)), eventIndex: 1 });
-            let event = withContent({
-                body: "bar",
-                msgtype: "m.text",
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "event_id_1"
-                    }
-                }
-            }, createEvent("m.room.message", "event_id_2", bob));
-            const entryB = new EventEntry({ event, eventIndex: 2 });
+            const entryB = new EventEntry({ event: withReply("event_id_1", createEvent("m.room.message", "event_id_2", bob)), eventIndex: 2 });
             await timeline.load(new User(alice), "join", new NullLogItem());
             timeline.entries.subscribe({ onAdd: () => null, onUpdate: () => null });
             timeline.addEntries([entryB]);

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -287,7 +287,7 @@ export class Timeline {
                 contextEvent.addDependent(entry);
                 entry.setContextEntry(contextEvent);
                 // emit this change
-                this._remoteEntries.update(entry);
+                this._findAndUpdateRelatedEntry(null, entry.id, () => true);
             }
         }
     }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -101,7 +101,6 @@ export class Timeline {
                 pe => this._mapPendingEventToEntry(pe),
                 (pee, params) => {
                     // is sending but redacted, who do we detect that here to remove the relation?
-                    this._loadContextEntriesWhereNeeded([pee]);
                     pee.notifyUpdate(params);
                 },
                 pee => this._applyAndEmitLocalRelationChange(pee, target => target.removeLocalRelation(pee))

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -289,8 +289,10 @@ export class Timeline {
         for (const entry of entries) {
             const fetchedEntry = this._contextEntriesNotInTimeline.get(entry.id);
             if (fetchedEntry) {
-                fetchedEntry.contextForEntries.forEach(e => e.setContextEntry(entry));
-                entry.updateFrom(fetchedEntry);
+                fetchedEntry.contextForEntries.forEach(e => {
+                    e.setContextEntry(entry);
+                    this._updateEntry(e);
+                });
                 this._contextEntriesNotInTimeline.delete(entry.id);
             }
         }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -604,8 +604,7 @@ export function tests() {
             // 1. setup timeline
             const pendingEvents = new ObservableArray();
             const timeline = new Timeline({roomId, storage: await createMockStorage(),
-                closeCallback: () => { }, fragmentIdComparer, pendingEvents, clock: new MockClock(),
-                fetchEventFromStorage: () => undefined, fetchEventFromHomeserver: () => undefined});
+                closeCallback: () => { }, fragmentIdComparer, pendingEvents, clock: new MockClock()});
             await timeline.load(new User(bob), "join", new NullLogItem());
             timeline.entries.subscribe(new ListObserver());
             // 2. add message and reaction to timeline

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -765,9 +765,24 @@ export function tests() {
         },
 
         "context entry is fetched from hs": async assert => {
+            const hsApi = {
+                context() {
+                    const result = {
+                        event: withTextBody("foo", createEvent("m.room.message", "event_id_1", alice)),
+                        state: [{
+                            type: MEMBER_EVENT_TYPE,
+                            user_id: alice,
+                            content: {
+                                displayName: "",
+                                avatarUrl: ""
+                            }
+                        }]
+                    };
+                    return { response: () => result };
+                }
+            };
             const timeline = new Timeline({roomId, storage: await createMockStorage(), closeCallback: () => {},
-                fragmentIdComparer, pendingEvents: new ObservableArray(), clock: new MockClock()});
-            const entryA = new EventEntry({ event: withTextBody("foo", createEvent("m.room.message", "event_id_1", alice)), eventIndex: 1 });
+                fragmentIdComparer, pendingEvents: new ObservableArray(), clock: new MockClock(), hsApi});
             let event = withContent({
                 body: "bar",
                 msgtype: "m.text",
@@ -778,12 +793,11 @@ export function tests() {
                 }
             }, createEvent("m.room.message", "event_id_2", bob));
             const entryB = new EventEntry({ event, eventIndex: 2 });
-            timeline._getEventFromHomeserver = () => entryA
             await timeline.load(new User(alice), "join", new NullLogItem());
             timeline.entries.subscribe({ onAdd: () => null, onUpdate: () => null });
             timeline.addEntries([entryB]);
             await poll(() => entryB.contextEntry);
-            assert.deepEqual(entryB.contextEntry, entryA);
+            assert.strictEqual(entryB.contextEntry.id, "event_id_1");
         },
 
         "context entry has a list of entries to which it forms the context": async assert => {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -245,9 +245,9 @@ export class Timeline {
     }
 
     async _loadRelatedEvents(entries) {
-        const filteredEntries = entries.filter(e => !!e.relation);
+        const filteredEntries = entries.filter(e => !!e.contextEventId);
         for (const entry of filteredEntries) {
-            const id = entry.relatedEventId;
+            const id = entry.contextEventId;
             let contextEvent;
             // find in remote events
             contextEvent = this.getByEventId(id);

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -278,9 +278,7 @@ export class Timeline {
             const relatedEntry = this._contextEntriesNotInTimeline.get(entry.relatedEventId);
             if (relatedEntry?.isNonPersisted && relatedEntry?.addLocalRelation(entry)) {
                 // update other entries for which this entry is a context entry
-                relatedEntry.contextForEntries?.forEach(e => {
-                    this._remoteEntries.findAndUpdate(te => te.id === e.id, () => "contextEntry");
-                });
+                relatedEntry.contextForEntries?.forEach(e => this._emitUpdateForEntry(e, "contextEntry"));
             }
         }
     }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -275,7 +275,7 @@ export class Timeline {
             if (relatedEntry?.addRelation(entry)) {
                 // update other entries for which this entry is a context entry
                 relatedEntry.contextForEntries?.forEach(e => {
-                    this._remoteEntries.findAndUpdate(te => te.id === e.id, () => { return { reply: relatedEntry }; });
+                    this._remoteEntries.findAndUpdate(te => te.id === e.id, () => true);
                 });
             }
         }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -279,6 +279,12 @@ export class Timeline {
         }
     }
 
+    /**
+     * Creates a new entry based on two related entries
+     * @param {EventEntry} entry an entry
+     * @param {EventEntry} relatedEntry `entry` specifies something about this entry (eg: this entry is redacted)
+     * @returns a new entry or undefined
+     */
     _createEntryFromRelatedEntries(entry, relatedEntry) {
         if (entry.isRedaction) {
             const newEntry = relatedEntry.clone();

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -274,7 +274,7 @@ export class Timeline {
          */
         for (const entry of entries) {
             const relatedEntry = this._contextEntriesNotInTimeline.get(entry.relatedEventId);
-            if (relatedEntry?.addRelation(entry)) {
+            if (relatedEntry?.isNonPersisted && relatedEntry?.addRelation(entry)) {
                 // update other entries for which this entry is a context entry
                 relatedEntry.contextForEntries?.forEach(e => {
                     this._remoteEntries.findAndUpdate(te => te.id === e.id, () => "contextEntry");

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -313,8 +313,10 @@ export class Timeline {
      * @param {EventEntry[]} entries 
      */
     async _loadContextEntriesWhereNeeded(entries) {
-        const entriesNeedingContext = entries.filter(e => !!e.contextEventId);
-        for (const entry of entriesNeedingContext) {
+        for (const entry of entries) {
+            if (!entry.contextEventId) {
+                continue;
+            }
             const id = entry.contextEventId;
             let contextEvent = this._getTrackedEntry(id);
             if (!contextEvent) {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -344,7 +344,7 @@ export class Timeline {
      * @returns entry if found, undefined otherwise
      */
     _findLoadedEventById(eventId) {
-        return this.getFromAllEntriesById(eventId) ?? this._contextEntriesNotInTimeline.get(eventId);
+        return this.getByEventId(eventId) ?? this._contextEntriesNotInTimeline.get(eventId);
     }
 
     async _getEventFromStorage(eventId) {
@@ -416,19 +416,6 @@ export class Timeline {
     getByEventId(eventId) {
         for (let i = 0; i < this._remoteEntries.length; i += 1) {
             const entry = this._remoteEntries.get(i);
-            if (entry.id === eventId) {
-                return entry;
-            }
-        }
-        return null;
-    }
-
-    getFromAllEntriesById(eventId) {
-        if (!this._allEntries) {
-            // if allEntries isn't loaded yet, fallback to looking only in remoteEntries
-            return this.getByEventId(eventId);
-        }
-        for (const entry of this._allEntries) {
             if (entry.id === eventId) {
                 return entry;
             }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -224,11 +224,14 @@ export class Timeline {
     /** @package */
     replaceEntries(entries) {
         this._addLocalRelationsToNewRemoteEntries(entries);
-        this._updateEntriesNotInTimeline(entries);
-        this._loadContextEntriesWhereNeeded(entries);
         for (const entry of entries) {
             try {
                 this._remoteEntries.getAndUpdate(entry, Timeline._entryUpdater);
+                const oldEntry = this._contextEntriesNotInTimeline.get(entry.id)
+                if (oldEntry) {
+                    Timeline._entryUpdater(oldEntry, entry);
+                }
+                this._contextEntriesNotInTimeline.set(entry.id, entry);
                 // Since this entry changed, all dependent entries should be updated
                 entry.contextForEntries?.forEach(e => this._updateEntry(e));
             } catch (err) {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -318,7 +318,7 @@ export class Timeline {
                 continue;
             }
             const id = entry.contextEventId;
-            let contextEvent = this._getTrackedEntry(id);
+            let contextEvent = this._findLoadedEventById(id);
             if (!contextEvent) {
                 contextEvent = await this._getEventFromStorage(id) ?? await this._getEventFromHomeserver(id);
                 if (contextEvent) {
@@ -339,7 +339,7 @@ export class Timeline {
      * @param {string} eventId event-id of the entry
      * @returns entry if found, undefined otherwise
      */
-    _getTrackedEntry(eventId) {
+    _findLoadedEventById(eventId) {
         return this.getByEventId(eventId) ?? this._contextEntriesNotInTimeline.get(eventId);
     }
 

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -256,8 +256,10 @@ export class Timeline {
     }
 
     _updateFetchedEntries(entries) {
+        // Update fetchedEntries based on incoming event, eg: a fetched event being redacted
         for (const entry of entries) {
             const relatedEntry = this._fetchedEventEntries.get(entry.relatedEventId);
+            // todo: can this be called .addRelation instead?
             if (relatedEntry?.addLocalRelation(entry)) {
                 relatedEntry.dependents.forEach(e => this._updateEntry(e));
             }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -214,7 +214,7 @@ export class Timeline {
     }
 
     /** @package */
-     replaceEntries(entries) {
+    replaceEntries(entries) {
         this._addLocalRelationsToNewRemoteEntries(entries);
         this._loadRelatedEvents(entries);
         for (const entry of entries) {

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -275,7 +275,7 @@ export class Timeline {
             if (relatedEntry?.addRelation(entry)) {
                 // update other entries for which this entry is a context entry
                 relatedEntry.contextForEntries?.forEach(e => {
-                    this._remoteEntries.findAndUpdate(te => te.id === e.id, () => true);
+                    this._remoteEntries.findAndUpdate(te => te.id === e.id, () => "contextEntry");
                 });
             }
         }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -25,6 +25,7 @@ import {getRelation, ANNOTATION_RELATION_TYPE} from "./relations.js";
 import {REDACTION_TYPE} from "../common.js";
 import {NonPersistedEventEntry} from "./entries/NonPersistedEventEntry.js";
 import {DecryptionSource} from "../../e2ee/common.js";
+import {EVENT_TYPE as MEMBER_EVENT_TYPE} from "../members/RoomMember.js";
 
 export class Timeline {
     constructor({roomId, storage, closeCallback, fragmentIdComparer, pendingEvents, clock, powerLevelsObservable, hsApi}) {
@@ -290,7 +291,7 @@ export class Timeline {
     async _getEventFromHomeserver(eventId) {
         const response = await this._hsApi.context(this._roomId, eventId, 0).response();
         const sender = response.event.sender;
-        const member = response.state.find(e => e.type === "m.room.member" && e.user_id === sender);
+        const member = response.state.find(e => e.type === MEMBER_EVENT_TYPE && e.user_id === sender);
         const entry = {
             event: response.event,
             displayName: member.content.displayname,

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -101,6 +101,7 @@ export class Timeline {
                 pe => this._mapPendingEventToEntry(pe),
                 (pee, params) => {
                     // is sending but redacted, who do we detect that here to remove the relation?
+                    this._loadContextEntriesWhereNeeded([pee]);
                     pee.notifyUpdate(params);
                 },
                 pee => this._applyAndEmitLocalRelationChange(pee, target => target.removeLocalRelation(pee))
@@ -124,6 +125,7 @@ export class Timeline {
             pendingEvent: pe, member: this._ownMember,
             clock: this._clock, redactingEntry
         });
+        this._loadContextEntriesWhereNeeded([pee]);
         this._applyAndEmitLocalRelationChange(pee, target => target.addRelation(pee));
         return pee;
     }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -248,19 +248,19 @@ export class Timeline {
         const filteredEntries = entries.filter(e => !!e.relation);
         for (const entry of filteredEntries) {
             const id = entry.relatedEventId;
-            let relatedEvent;
+            let contextEvent;
             // find in remote events
-            relatedEvent = this.getByEventId(id);
+            contextEvent = this.getByEventId(id);
             // find in storage
-            if (!relatedEvent) {
-                relatedEvent = await this._fetchEventFromStorage(id);
+            if (!contextEvent) {
+                contextEvent = await this._fetchEventFromStorage(id);
             }
             // fetch from hs
-            if (!relatedEvent) {
-                relatedEvent = await this._fetchEventFromHomeserver(id);
+            if (!contextEvent) {
+                contextEvent = await this._fetchEventFromHomeserver(id);
             }
-            if (relatedEvent) {
-                entry.setRelatedEntry(relatedEvent);
+            if (contextEvent) {
+                entry.setContextEntry(contextEvent);
             }
         }
     }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -125,7 +125,7 @@ export class Timeline {
             clock: this._clock, redactingEntry
         });
         this._loadContextEntriesWhereNeeded([pee]);
-        this._applyAndEmitLocalRelationChange(pee, target => target.addRelation(pee));
+        this._applyAndEmitLocalRelationChange(pee, target => target.addLocalRelation(pee));
         return pee;
     }
 
@@ -204,12 +204,12 @@ export class Timeline {
             if (pee.relatedEventId) {
                 const relationTarget = entries.find(e => e.id === pee.relatedEventId);
                 // no need to emit here as this entry is about to be added
-                relationTarget?.addRelation(pee);
+                relationTarget?.addLocalRelation(pee);
             }
             if (pee.redactingEntry) {
                 const eventId = pee.redactingEntry.relatedEventId;
                 const relationTarget = entries.find(e => e.id === eventId);
-                relationTarget?.addRelation(pee);
+                relationTarget?.addLocalRelation(pee);
             }
         }
     }
@@ -275,7 +275,7 @@ export class Timeline {
          */
         for (const entry of entries) {
             const relatedEntry = this._contextEntriesNotInTimeline.get(entry.relatedEventId);
-            if (relatedEntry?.isNonPersisted && relatedEntry?.addRelation(entry)) {
+            if (relatedEntry?.isNonPersisted && relatedEntry?.addLocalRelation(entry)) {
                 // update other entries for which this entry is a context entry
                 relatedEntry.contextForEntries?.forEach(e => {
                     this._remoteEntries.findAndUpdate(te => te.id === e.id, () => "contextEntry");

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -422,8 +422,11 @@ export class Timeline {
     }
 
     getFromAllEntriesById(eventId) {
-        for (let i = 0; i < this.entries.length; i += 1) {
-            const entry = this.entries.get(i);
+        if (!this._allEntries) {
+            // if allEntries isn't loaded yet, fallback to looking only in remoteEntries
+            return this.getByEventId(eventId);
+        }
+        for (const entry of this._allEntries) {
             if (entry.id === eventId) {
                 return entry;
             }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -251,6 +251,7 @@ export class Timeline {
     addEntries(newEntries) {
         this._addLocalRelationsToNewRemoteEntries(newEntries);
         this._updateFetchedEntries(newEntries);
+        this._moveFetchedEntryToRemoteEntries(newEntries);
         this._loadRelatedEvents(newEntries);
         this._remoteEntries.setManySorted(newEntries);
     }
@@ -262,6 +263,17 @@ export class Timeline {
             // todo: can this be called .addRelation instead?
             if (relatedEntry?.addLocalRelation(entry)) {
                 relatedEntry.dependents.forEach(e => this._updateEntry(e));
+            }
+        }
+    }
+
+    _moveFetchedEntryToRemoteEntries(entries) {
+        // if some entry in entries is also in fetchedEntries, we need to remove it from fetchedEntries
+        for (const entry of entries) {
+            const fetchedEntry = this._fetchedEventEntries.get(entry.id);
+            if (fetchedEntry) {
+                fetchedEntry.dependents.forEach(e => e.setContextEntry(entry));
+                entry.updateFrom(fetchedEntry);
             }
         }
     }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -233,7 +233,7 @@ export class Timeline {
                     this._contextEntriesNotInTimeline.set(entry.id, entry);
                 }
                 // Since this entry changed, all dependent entries should be updated
-                entry.contextForEntries?.forEach(e => this._updateEntry(e));
+                entry.contextForEntries?.forEach(e => this._emitUpdateForEntry(e));
             } catch (err) {
                 if (err.name === "CompareError") {
                     // see FragmentIdComparer, if the replacing entry is on a fragment
@@ -291,14 +291,14 @@ export class Timeline {
             if (fetchedEntry) {
                 fetchedEntry.contextForEntries.forEach(e => {
                     e.setContextEntry(entry);
-                    this._updateEntry(e);
+                    this._emitUpdateForEntry(e);
                 });
                 this._contextEntriesNotInTimeline.delete(entry.id);
             }
         }
     }
 
-    _updateEntry(entry) {
+    _emitUpdateForEntry(entry) {
         const txnId = entry.isPending ? entry.id : null;
         const eventId = entry.isPending ? null : entry.id;
         this._findAndUpdateEntryById(txnId, eventId, () => true);
@@ -327,7 +327,7 @@ export class Timeline {
             }
             if (contextEvent) {
                 entry.setContextEntry(contextEvent);
-                this._updateEntry(entry);
+                this._emitUpdateForEntry(entry);
             }
         }
     }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -141,6 +141,7 @@ export class Timeline {
             // redactingEntry might be a PendingEventEntry or an EventEntry, so don't assume pendingEvent
             const relatedTxnId = pee.redactingEntry.pendingEvent?.relatedTxnId;
             this._findAndUpdateEntryById(relatedTxnId, pee.redactingEntry.relatedEventId, updateOrFalse);
+            pee.redactingEntry.contextForEntries?.forEach(e => this._emitUpdateForEntry(e));
         }
     }
 

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -48,6 +48,7 @@ export class Timeline {
         this._allEntries = null;
         /** Stores event entries that we had to fetch from hs/storage for reply previews (because they were not in timeline) */ 
         this._contextEntriesNotInTimeline = new Map();
+        /** Only used to decrypt non-persisted context entries fetched from the homeserver */
         this._decryptEntries = null;
         this._hsApi = hsApi;
         this.initializePowerLevels(powerLevelsObservable);

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -340,7 +340,6 @@ export class Timeline {
                 }
             }
             if (contextEvent) {
-                contextEvent.setAsContextOf(entry);
                 entry.setContextEntry(contextEvent);
                 this._updateEntry(entry);
             }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -751,6 +751,8 @@ export function tests() {
             }, createEvent("m.room.message", "event_id_2", bob));
             const entryB = new EventEntry({ event });
             await timeline.load(new User(alice), "join", new NullLogItem());
+            timeline._setupEntries([]);
+            timeline._localEntries.onSubscribeFirst();
             timeline._remoteEntries.setManyUnsorted([entryA, entryB]);
             await timeline._loadContextEntriesWhereNeeded([entryA, entryB]);
             assert.deepEqual(entryB.contextEntry, entryA);
@@ -772,6 +774,8 @@ export function tests() {
             const entryB = new EventEntry({ event });
             timeline._getEventFromStorage = () => entryA
             await timeline.load(new User(alice), "join", new NullLogItem());
+            timeline._setupEntries([]);
+            timeline._localEntries.onSubscribeFirst();
             await timeline._loadContextEntriesWhereNeeded([entryB]);
             assert.deepEqual(entryB.contextEntry, entryA);
         },
@@ -792,6 +796,8 @@ export function tests() {
             const entryB = new EventEntry({ event });
             timeline._getEventFromHomeserver = () => entryA
             await timeline.load(new User(alice), "join", new NullLogItem());
+            timeline._setupEntries([]);
+            timeline._localEntries.onSubscribeFirst();
             await timeline._loadContextEntriesWhereNeeded([entryB]);
             assert.deepEqual(entryB.contextEntry, entryA);
         },
@@ -811,7 +817,12 @@ export function tests() {
             };
             const entryB = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_2", bob)) });
             const entryC = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_3", bob)) });
+            entryA._eventEntry.eventIndex = 1;
+            entryB._eventEntry.eventIndex = 2;
+            entryC._eventEntry.eventIndex = 3;
             await timeline.load(new User(alice), "join", new NullLogItem());
+            timeline._setupEntries([]);
+            timeline._localEntries.onSubscribeFirst();
             timeline._remoteEntries.setManyUnsorted([entryA, entryB, entryC]);
             await timeline._loadContextEntriesWhereNeeded([entryA, entryB, entryC]);
             assert.deepEqual(entryA.contextForEntries, [entryB, entryC]);
@@ -834,6 +845,8 @@ export function tests() {
             timeline._getEventFromStorage = () => null;
             timeline._getEventFromHomeserver = () => entryA;
             await timeline.load(new User(alice), "join", new NullLogItem());
+            timeline._setupEntries([]);
+            timeline._localEntries.onSubscribeFirst();
             await timeline._loadContextEntriesWhereNeeded([entryB]);
             const redactingEntry = new EventEntry({ event: withRedacts(entryA.id, "foo", createEvent("m.room.redaction", "event_id_3", alice)) });
             timeline.addEntries([redactingEntry]);
@@ -856,7 +869,12 @@ export function tests() {
             };
             const entryB = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_2", bob)) });
             const entryC = new EventEntry({ event: withContent(content, createEvent("m.room.message", "event_id_3", bob)) });
+            entryA._eventEntry.eventIndex = 1;
+            entryB._eventEntry.eventIndex = 2;
+            entryC._eventEntry.eventIndex = 3;
             await timeline.load(new User(alice), "join", new NullLogItem());
+            timeline._setupEntries([]);
+            timeline._localEntries.onSubscribeFirst();
             timeline._getEventFromStorage = () => null;
             timeline._getEventFromHomeserver = () => entryA;
             timeline.addEntries([entryB, entryC]);
@@ -888,8 +906,12 @@ export function tests() {
                 }
             }, createEvent("m.room.message", "event_id_2", bob));
             const entryB = new EventEntry({ event });
+            entryA._eventEntry.eventIndex = 1;
+            entryB._eventEntry.eventIndex = 2;
             timeline._getEventFromHomeserver = () => entryA
             await timeline.load(new User(alice), "join", new NullLogItem());
+            timeline._setupEntries([]);
+            timeline._localEntries.onSubscribeFirst();
             timeline.addEntries([entryB]);
             await timeline._loadContextEntriesWhereNeeded([entryB]);
             assert.strictEqual(timeline._contextEntriesNotInTimeline.has(entryA.id), true);

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -337,12 +337,12 @@ export class Timeline {
     }
 
     /**
-     * Fetches an entry with the given event-id from remoteEntries or contextEntriesNotInTimeline.
+     * Fetches an entry with the given event-id from localEntries, remoteEntries or contextEntriesNotInTimeline.
      * @param {string} eventId event-id of the entry
      * @returns entry if found, undefined otherwise
      */
     _findLoadedEventById(eventId) {
-        return this.getByEventId(eventId) ?? this._contextEntriesNotInTimeline.get(eventId);
+        return this.getFromAllEntriesById(eventId) ?? this._contextEntriesNotInTimeline.get(eventId);
     }
 
     async _getEventFromStorage(eventId) {
@@ -414,6 +414,16 @@ export class Timeline {
     getByEventId(eventId) {
         for (let i = 0; i < this._remoteEntries.length; i += 1) {
             const entry = this._remoteEntries.get(i);
+            if (entry.id === eventId) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    getFromAllEntriesById(eventId) {
+        for (let i = 0; i < this.entries.length; i += 1) {
+            const entry = this.entries.get(i);
             if (entry.id === eventId) {
                 return entry;
             }

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -297,9 +297,11 @@ export class Timeline {
             let contextEvent = this._getTrackedEvent(id);
             if (!contextEvent) {
                 contextEvent = await this._getEventFromStorage(id) ?? await this._getEventFromHomeserver(id);
-                // this entry was created from storage/hs, so it's not tracked by remoteEntries
-                // we track them here so that we can update reply previews later 
-                this._contextEntriesNotInTimeline.set(id, contextEvent);
+                if (contextEvent) {
+                    // this entry was created from storage/hs, so it's not tracked by remoteEntries
+                    // we track them here so that we can update reply previews later
+                    this._contextEntriesNotInTimeline.set(id, contextEvent);
+                }
             }
             if (contextEvent) {
                 contextEvent.setAsContextOf(entry);

--- a/src/matrix/room/timeline/common.js
+++ b/src/matrix/room/timeline/common.js
@@ -17,3 +17,50 @@ limitations under the License.
 export function isValidFragmentId(id) {
     return typeof id === "number";
 }
+
+// copied over from matrix-js-sdk, copyright 2016 OpenMarket Ltd
+/* _REDACT_KEEP_KEY_MAP gives the keys we keep when an event is redacted
+ *
+ * This is specified here:
+ *  http://matrix.org/speculator/spec/HEAD/client_server/latest.html#redactions
+ *
+ * Also:
+ *  - We keep 'unsigned' since that is created by the local server
+ *  - We keep user_id for backwards-compat with v1
+ */
+const _REDACT_KEEP_KEY_MAP = [
+    'event_id', 'type', 'room_id', 'user_id', 'sender', 'state_key', 'prev_state',
+    'content', 'unsigned', 'origin_server_ts',
+].reduce(function(ret, val) {
+    ret[val] = 1; return ret;
+}, {});
+
+// a map from event type to the .content keys we keep when an event is redacted
+const _REDACT_KEEP_CONTENT_MAP = {
+    'm.room.member': {'membership': 1},
+    'm.room.create': {'creator': 1},
+    'm.room.join_rules': {'join_rule': 1},
+    'm.room.power_levels': {'ban': 1, 'events': 1, 'events_default': 1,
+                            'kick': 1, 'redact': 1, 'state_default': 1,
+                            'users': 1, 'users_default': 1,
+                           },
+    'm.room.aliases': {'aliases': 1},
+};
+// end of matrix-js-sdk code
+
+export function redactEvent(redactionEvent, redactedEvent) {
+    for (const key of Object.keys(redactedEvent)) {
+        if (!_REDACT_KEEP_KEY_MAP[key]) {
+            delete redactedEvent[key];
+        }
+    }
+    const { content } = redactedEvent;
+    const keepMap = _REDACT_KEEP_CONTENT_MAP[redactedEvent.type];
+    for (const key of Object.keys(content)) {
+        if (!keepMap?.[key]) {
+            delete content[key];
+        }
+    }
+    redactedEvent.unsigned = redactedEvent.unsigned || {};
+    redactedEvent.unsigned.redacted_because = redactionEvent;
+}

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -53,10 +53,13 @@ export class BaseEventEntry extends BaseEntry {
     }
 
     /**
-        aggregates local relation or local redaction of remote relation.
+        Aggregates relation or redaction of remote relation.  
+        Used in two situations:
+        - to aggregate local relation/redaction of remote relation
+        - to mark this entry as being redacted in Timeline._updateEntriesFetchedFromHomeserver
         @return [string] returns the name of the field that has changed, if any
     */
-    addLocalRelation(entry) {
+    addRelation(entry) {
         if (entry.eventType === REDACTION_TYPE && entry.isRelatedToId(this.id)) {
             if (!this._pendingRedactions) {
                 this._pendingRedactions = [];

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -81,7 +81,7 @@ export class BaseEventEntry extends BaseEntry {
         - to mark this entry as being redacted in Timeline._updateEntriesFetchedFromHomeserver
         @return [string] returns the name of the field that has changed, if any
     */
-    addRelation(entry) {
+    addLocalRelation(entry) {
         if (entry.eventType === REDACTION_TYPE && entry.isRelatedToId(this.id)) {
             if (!this._pendingRedactions) {
                 this._pendingRedactions = [];

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -27,6 +27,8 @@ export class BaseEventEntry extends BaseEntry {
         super(fragmentIdComparer);
         this._pendingRedactions = null;
         this._pendingAnnotations = null;
+        this._contextEntry = null;
+        this._contextForEntries = null;
     }
 
     get isReply() {
@@ -50,6 +52,26 @@ export class BaseEventEntry extends BaseEntry {
             return this._pendingRedactions[0].content?.reason;
         }
         return null;
+    }
+
+    setContextEntry(entry) {
+        this._contextEntry = entry;
+        entry._setAsContextOf(this);
+    }
+
+    _setAsContextOf(entry) {
+        if (!this._contextForEntries) {
+            this._contextForEntries = [];
+        }
+        this._contextForEntries.push(entry);
+    }
+
+    get contextForEntries() {
+        return this._contextForEntries;
+    }
+
+    get contextEntry() {
+        return this._contextEntry;
     }
 
     /**

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -146,7 +146,7 @@ export class EventEntry extends BaseEventEntry {
         return getRelatedEventId(this.event);
     }
 
-    // similar to relatedEventID but excludes relations like redaction
+    // similar to relatedEventID but only for replies
     get contextEventId() {
         if (this.isReply) {
             return this.relatedEventId;

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -42,7 +42,8 @@ export class EventEntry extends BaseEventEntry {
         if (other._decryptionError && !this._decryptionError) {
             this._decryptionError = other._decryptionError;
         }
-        this._contextForEntries = other._contextForEntries;
+        this._contextForEntries = other.contextForEntries;
+        this._contextEntry = other.contextEntry;
     }
 
     setContextEntry(entry) {

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -26,6 +26,7 @@ export class EventEntry extends BaseEventEntry {
         this._decryptionResult = null;
         this._contextEntry = null;
         this._contextForEntries = null;
+        this._markedAsRedacted = false;
     }
 
     clone() {
@@ -53,6 +54,10 @@ export class EventEntry extends BaseEventEntry {
             this._contextForEntries = [];
         }
         this._contextForEntries.push(entry);
+    }
+
+    setAsRedacted() {
+        this._markedAsRedacted = true;
     }
 
     get contextForEntries() {
@@ -153,7 +158,7 @@ export class EventEntry extends BaseEventEntry {
     }
 
     get isRedacted() {
-        return super.isRedacted || isRedacted(this._eventEntry.event);
+        return this._markedAsRedacted || super.isRedacted || isRedacted(this._eventEntry.event);
     }
 
     get redactionReason() {

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -24,8 +24,6 @@ export class EventEntry extends BaseEventEntry {
         this._eventEntry = eventEntry;
         this._decryptionError = null;
         this._decryptionResult = null;
-        this._contextEntry = null;
-        this._contextForEntries = null;
     }
 
     clone() {
@@ -45,20 +43,8 @@ export class EventEntry extends BaseEventEntry {
         this._contextEntry = other.contextEntry;
     }
 
-    setContextEntry(entry) {
-        this._contextEntry = entry;
-        entry._setAsContextOf(this);
-    }
-
-    _setAsContextOf(entry) {
-        if (!this._contextForEntries) {
-            this._contextForEntries = [];
-        }
-        this._contextForEntries.push(entry);
-    }
-
-    get contextForEntries() {
-        return this._contextForEntries;
+    setRelatedEntry(entry) {
+        this._relatedEntry = entry;
     }
 
     get event() {
@@ -142,16 +128,11 @@ export class EventEntry extends BaseEventEntry {
         return getRelatedEventId(this.event);
     }
 
-    // similar to relatedEventID but only for replies
-    get contextEventId() {
-        if (this.isReply) {
-            return this.relatedEventId;
+    get threadEventId() {
+        if (this.isThread) {
+            return this.relation?.event_id;
         }
         return null;
-    }
-
-    get contextEntry() {
-        return this._contextEntry;
     }
 
     get isRedacted() {
@@ -176,6 +157,15 @@ export class EventEntry extends BaseEventEntry {
         const originalRelation = originalContent && getRelationFromContent(originalContent);
         return originalRelation || getRelationFromContent(this.content);
     }
+
+    // similar to relatedEventID but only for replies
+    get contextEventId() {
+        if (this.isReply) {
+            return this.relatedEventId;
+        }
+        return null;
+    }
+
 }
 
 import {withTextBody, withContent, createEvent} from "../../../../mocks/event.js";

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -180,7 +180,7 @@ export function tests() {
 
     function addPendingReaction(target, key) {
         queueIndex += 1;
-        target.addRelation(new PendingEventEntry({
+        target.addLocalRelation(new PendingEventEntry({
             pendingEvent: new PendingEvent({data: {
                 eventType: "m.reaction",
                 content: createAnnotation(target.id, key),
@@ -202,7 +202,7 @@ export function tests() {
             });
         }
         queueIndex += 1;
-        target.addRelation(new PendingEventEntry({
+        target.addLocalRelation(new PendingEventEntry({
             pendingEvent: new PendingEvent({data: {
                 eventType: "m.room.redaction",
                 relatedTxnId: pendingReaction ? pendingReaction.id : null,

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -124,13 +124,6 @@ export class EventEntry extends BaseEventEntry {
         return getRelatedEventId(this.event);
     }
 
-    get threadEventId() {
-        if (this.isThread) {
-            return this.relation?.event_id;
-        }
-        return null;
-    }
-
     get isRedacted() {
         return super.isRedacted || isRedacted(this._eventEntry.event);
     }

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -43,10 +43,6 @@ export class EventEntry extends BaseEventEntry {
         this._contextEntry = other.contextEntry;
     }
 
-    setRelatedEntry(entry) {
-        this._relatedEntry = entry;
-    }
-
     get event() {
         return this._eventEntry.event;
     }

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -190,7 +190,7 @@ export function tests() {
 
     function addPendingReaction(target, key) {
         queueIndex += 1;
-        target.addLocalRelation(new PendingEventEntry({
+        target.addRelation(new PendingEventEntry({
             pendingEvent: new PendingEvent({data: {
                 eventType: "m.reaction",
                 content: createAnnotation(target.id, key),
@@ -212,7 +212,7 @@ export function tests() {
             });
         }
         queueIndex += 1;
-        target.addLocalRelation(new PendingEventEntry({
+        target.addRelation(new PendingEventEntry({
             pendingEvent: new PendingEvent({data: {
                 eventType: "m.room.redaction",
                 relatedTxnId: pendingReaction ? pendingReaction.id : null,

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -26,7 +26,6 @@ export class EventEntry extends BaseEventEntry {
         this._decryptionResult = null;
         this._contextEntry = null;
         this._contextForEntries = null;
-        this._markedAsRedacted = false;
     }
 
     clone() {
@@ -56,10 +55,6 @@ export class EventEntry extends BaseEventEntry {
             this._contextForEntries = [];
         }
         this._contextForEntries.push(entry);
-    }
-
-    setAsRedacted() {
-        this._markedAsRedacted = true;
     }
 
     get contextForEntries() {
@@ -160,7 +155,7 @@ export class EventEntry extends BaseEventEntry {
     }
 
     get isRedacted() {
-        return this._markedAsRedacted || super.isRedacted || isRedacted(this._eventEntry.event);
+        return super.isRedacted || isRedacted(this._eventEntry.event);
     }
 
     get redactionReason() {

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -25,6 +25,7 @@ export class EventEntry extends BaseEventEntry {
         this._decryptionError = null;
         this._decryptionResult = null;
         this._contextEntry = null;
+        this._dependents = null;
     }
 
     clone() {
@@ -40,10 +41,22 @@ export class EventEntry extends BaseEventEntry {
         if (other._decryptionError && !this._decryptionError) {
             this._decryptionError = other._decryptionError;
         }
+        this._dependents = other._dependents;
     }
 
     setContextEntry(entry) {
         this._contextEntry = entry;
+    }
+
+    addDependent(entry) {
+        if (!this._dependents) {
+            this._dependents = [];
+        }
+        this._dependents.push(entry);
+    }
+
+    get dependents() {
+        return this._dependents;
     }
 
     get event() {

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -24,6 +24,7 @@ export class EventEntry extends BaseEventEntry {
         this._eventEntry = eventEntry;
         this._decryptionError = null;
         this._decryptionResult = null;
+        this._relatedEntry = null;
     }
 
     clone() {
@@ -39,6 +40,10 @@ export class EventEntry extends BaseEventEntry {
         if (other._decryptionError && !this._decryptionError) {
             this._decryptionError = other._decryptionError;
         }
+    }
+
+    setRelatedEntry(entry) {
+        this._relatedEntry = entry;
     }
 
     get event() {
@@ -120,6 +125,10 @@ export class EventEntry extends BaseEventEntry {
 
     get relatedEventId() {
         return getRelatedEventId(this.event);
+    }
+
+    get relatedEntry() {
+        return this._relatedEntry;
     }
 
     get isRedacted() {

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -127,8 +127,7 @@ export class EventEntry extends BaseEventEntry {
         return getRelatedEventId(this.event);
     }
 
-    // return a related event-id only if this entry is a reply
-    // excludes relations like redaction
+    // similar to relatedEventID but excludes relations like redaction
     get contextEventId() {
         if (this.isReply) {
             return this.relatedEventId;

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -48,6 +48,7 @@ export class EventEntry extends BaseEventEntry {
 
     setContextEntry(entry) {
         this._contextEntry = entry;
+        entry.setAsContextOf(this);
     }
 
     setAsContextOf(entry) {

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -127,6 +127,15 @@ export class EventEntry extends BaseEventEntry {
         return getRelatedEventId(this.event);
     }
 
+    // return a related event-id only if this entry is a reply
+    // excludes relations like redaction
+    get contextEventId() {
+        if (this.isReply) {
+            return this.relatedEventId;
+        }
+        return null;
+    }
+
     get contextEntry() {
         return this._contextEntry;
     }

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -25,7 +25,7 @@ export class EventEntry extends BaseEventEntry {
         this._decryptionError = null;
         this._decryptionResult = null;
         this._contextEntry = null;
-        this._dependents = null;
+        this._contextForEntries = null;
     }
 
     clone() {
@@ -41,22 +41,22 @@ export class EventEntry extends BaseEventEntry {
         if (other._decryptionError && !this._decryptionError) {
             this._decryptionError = other._decryptionError;
         }
-        this._dependents = other._dependents;
+        this._contextForEntries = other._contextForEntries;
     }
 
     setContextEntry(entry) {
         this._contextEntry = entry;
     }
 
-    addDependent(entry) {
-        if (!this._dependents) {
-            this._dependents = [];
+    setAsContextOf(entry) {
+        if (!this._contextForEntries) {
+            this._contextForEntries = [];
         }
-        this._dependents.push(entry);
+        this._contextForEntries.push(entry);
     }
 
-    get dependents() {
-        return this._dependents;
+    get contextForEntries() {
+        return this._contextForEntries;
     }
 
     get event() {

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -47,10 +47,10 @@ export class EventEntry extends BaseEventEntry {
 
     setContextEntry(entry) {
         this._contextEntry = entry;
-        entry.setAsContextOf(this);
+        entry._setAsContextOf(this);
     }
 
-    setAsContextOf(entry) {
+    _setAsContextOf(entry) {
         if (!this._contextForEntries) {
             this._contextForEntries = [];
         }

--- a/src/matrix/room/timeline/entries/EventEntry.js
+++ b/src/matrix/room/timeline/entries/EventEntry.js
@@ -24,7 +24,7 @@ export class EventEntry extends BaseEventEntry {
         this._eventEntry = eventEntry;
         this._decryptionError = null;
         this._decryptionResult = null;
-        this._relatedEntry = null;
+        this._contextEntry = null;
     }
 
     clone() {
@@ -42,8 +42,8 @@ export class EventEntry extends BaseEventEntry {
         }
     }
 
-    setRelatedEntry(entry) {
-        this._relatedEntry = entry;
+    setContextEntry(entry) {
+        this._contextEntry = entry;
     }
 
     get event() {
@@ -127,8 +127,8 @@ export class EventEntry extends BaseEventEntry {
         return getRelatedEventId(this.event);
     }
 
-    get relatedEntry() {
-        return this._relatedEntry;
+    get contextEntry() {
+        return this._contextEntry;
     }
 
     get isRedacted() {

--- a/src/matrix/room/timeline/entries/FragmentBoundaryEntry.js
+++ b/src/matrix/room/timeline/entries/FragmentBoundaryEntry.js
@@ -134,6 +134,6 @@ export class FragmentBoundaryEntry extends BaseEntry {
         return new FragmentBoundaryEntry(neighbour, !this._isFragmentStart, this._fragmentIdComparer);
     }
 
-    addLocalRelation() {}
+    addRelation() {}
     removeLocalRelation() {}
 }

--- a/src/matrix/room/timeline/entries/FragmentBoundaryEntry.js
+++ b/src/matrix/room/timeline/entries/FragmentBoundaryEntry.js
@@ -134,6 +134,6 @@ export class FragmentBoundaryEntry extends BaseEntry {
         return new FragmentBoundaryEntry(neighbour, !this._isFragmentStart, this._fragmentIdComparer);
     }
 
-    addRelation() {}
+    addLocalRelation() {}
     removeLocalRelation() {}
 }

--- a/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
+++ b/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
@@ -17,6 +17,8 @@ limitations under the License.
 import {EventEntry} from "./EventEntry.js";
 
 // EventEntry but without the two properties that are populated via SyncWriter
+// Useful if you want to create an EventEntry that is ephemeral
+
 export class NonPersistedEventEntry extends EventEntry {
     get fragmentId() {
         throw new Error("Cannot access fragmentId for non-persisted EventEntry");

--- a/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
+++ b/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import {EventEntry} from "./EventEntry.js";
+import {redactEvent} from "../common.js";
 
 // EventEntry but without the two properties that are populated via SyncWriter
 // Useful if you want to create an EventEntry that is ephemeral
@@ -26,5 +27,22 @@ export class NonPersistedEventEntry extends EventEntry {
 
     get entryIndex() {
         throw new Error("Cannot access entryIndex for non-persisted EventEntry");
+    }
+
+    /**
+     * This method is needed because NonPersistedEventEntry cannot rely on RelationWriter to handle redactions
+     */
+    redact(redactionEvent) {
+        redactEvent(redactionEvent.event, this.event);
+    }
+
+    clone() {
+        const clone = new NonPersistedEventEntry(this._eventEntry, this._fragmentIdComparer);
+        clone.updateFrom(this);
+        return clone;
+    }
+
+    get isNonPersisted() {
+        return true;
     }
 }

--- a/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
+++ b/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import {EventEntry} from "./EventEntry.js";
-import {redactEvent} from "../common.js";
 
 // EventEntry but without the two properties that are populated via SyncWriter
 // Useful if you want to create an EventEntry that is ephemeral
@@ -27,22 +26,5 @@ export class NonPersistedEventEntry extends EventEntry {
 
     get entryIndex() {
         throw new Error("Cannot access entryIndex for non-persisted EventEntry");
-    }
-
-    /**
-     * This method is needed because NonPersistedEventEntry cannot rely on RelationWriter to handle redactions
-     */
-    redact(redactionEvent) {
-        redactEvent(redactionEvent.event, this.event);
-    }
-
-    clone() {
-        const clone = new NonPersistedEventEntry(this._eventEntry, this._fragmentIdComparer);
-        clone.updateFrom(this);
-        return clone;
-    }
-
-    get isNonPersisted() {
-        return true;
     }
 }

--- a/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
+++ b/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
@@ -27,4 +27,8 @@ export class NonPersistedEventEntry extends EventEntry {
     get entryIndex() {
         throw new Error("Cannot access entryIndex for non-persisted EventEntry");
     }
+
+    get isNonPersisted() {
+        return true;
+    }
 }

--- a/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
+++ b/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
@@ -31,4 +31,14 @@ export class NonPersistedEventEntry extends EventEntry {
     get isNonPersisted() {
         return true;
     }
+
+    // overridden here because we reuse addLocalRelation() for updating this entry
+    // we don't want the RedactedTile created using this entry to ever show "is being redacted"
+    get isRedacting() {
+        return false;
+    }
+
+    get isRedacted() {
+        return !!this._pendingRedactions;
+    }
 }

--- a/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
+++ b/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
@@ -39,6 +39,6 @@ export class NonPersistedEventEntry extends EventEntry {
     }
 
     get isRedacted() {
-        return !!this._pendingRedactions;
+        return super.isRedacting;
     }
 }

--- a/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
+++ b/src/matrix/room/timeline/entries/NonPersistedEventEntry.js
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {EventEntry} from "./EventEntry.js";
+
+// EventEntry but without the two properties that are populated via SyncWriter
+export class NonPersistedEventEntry extends EventEntry {
+    get fragmentId() {
+        throw new Error("Cannot access fragmentId for non-persisted EventEntry");
+    }
+
+    get entryIndex() {
+        throw new Error("Cannot access entryIndex for non-persisted EventEntry");
+    }
+}

--- a/src/matrix/room/timeline/entries/PendingEventEntry.js
+++ b/src/matrix/room/timeline/entries/PendingEventEntry.js
@@ -100,4 +100,11 @@ export class PendingEventEntry extends BaseEventEntry {
     get redactingEntry() {
         return this._redactingEntry;
     }
+
+    get contextEventId() {
+        if (this.isReply) {
+            return this._pendingEvent.relatedEventId ?? this._pendingEvent.relatedTxnId;
+        }
+        return null;
+    }
 }

--- a/src/matrix/room/timeline/persistence/RelationWriter.js
+++ b/src/matrix/room/timeline/persistence/RelationWriter.js
@@ -17,6 +17,7 @@ limitations under the License.
 import {EventEntry} from "../entries/EventEntry.js";
 import {REDACTION_TYPE, isRedacted} from "../../common.js";
 import {ANNOTATION_RELATION_TYPE, getRelation} from "../relations.js";
+import {redactEvent} from "../common.js";
 
 export class RelationWriter {
     constructor({roomId, ownUserId, fragmentIdComparer}) {
@@ -127,21 +128,7 @@ export class RelationWriter {
         // check if we're the target of a relation and remove all relations then as well
         txn.timelineRelations.removeAllForTarget(this._roomId, redactedEvent.event_id);
 
-        for (const key of Object.keys(redactedEvent)) {
-            if (!_REDACT_KEEP_KEY_MAP[key]) {
-                delete redactedEvent[key];
-            }
-        }
-        const {content} = redactedEvent;
-        const keepMap = _REDACT_KEEP_CONTENT_MAP[redactedEvent.type];
-        for (const key of Object.keys(content)) {
-            if (!keepMap?.[key]) {
-                delete content[key];
-            }
-        }
-        redactedEvent.unsigned = redactedEvent.unsigned || {};
-        redactedEvent.unsigned.redacted_because = redactionEvent;
-
+        redactEvent(redactionEvent, redactedEvent);
         delete redactedStorageEntry.annotations;
 
         return true;
@@ -223,35 +210,6 @@ function isObjectEmpty(obj) {
     return true;
 }
 
-// copied over from matrix-js-sdk, copyright 2016 OpenMarket Ltd
-/* _REDACT_KEEP_KEY_MAP gives the keys we keep when an event is redacted
- *
- * This is specified here:
- *  http://matrix.org/speculator/spec/HEAD/client_server/latest.html#redactions
- *
- * Also:
- *  - We keep 'unsigned' since that is created by the local server
- *  - We keep user_id for backwards-compat with v1
- */
-const _REDACT_KEEP_KEY_MAP = [
-    'event_id', 'type', 'room_id', 'user_id', 'sender', 'state_key', 'prev_state',
-    'content', 'unsigned', 'origin_server_ts',
-].reduce(function(ret, val) {
-    ret[val] = 1; return ret;
-}, {});
-
-// a map from event type to the .content keys we keep when an event is redacted
-const _REDACT_KEEP_CONTENT_MAP = {
-    'm.room.member': {'membership': 1},
-    'm.room.create': {'creator': 1},
-    'm.room.join_rules': {'join_rule': 1},
-    'm.room.power_levels': {'ban': 1, 'events': 1, 'events_default': 1,
-                            'kick': 1, 'redact': 1, 'state_default': 1,
-                            'users': 1, 'users_default': 1,
-                           },
-    'm.room.aliases': {'aliases': 1},
-};
-// end of matrix-js-sdk code
 
 import {createMockStorage} from "../../../../mocks/Storage";
 import {createEvent, withTextBody, withRedacts, withContent} from "../../../../mocks/event.js";

--- a/src/matrix/room/timeline/persistence/TimelineReader.js
+++ b/src/matrix/room/timeline/persistence/TimelineReader.js
@@ -134,7 +134,7 @@ export class TimelineReader {
 
     async readById(id, log) {
         let stores = [this._storage.storeNames.timelineEvents];
-        if (this.isEncrypted) {
+        if (this._decryptEntries) {
             stores.push(this._storage.storeNames.inboundGroupSessions);
         }
         const txn = await this._storage.readTxn(stores); // todo: can we just use this.readTxnStores here? probably

--- a/src/matrix/room/timeline/persistence/TimelineReader.js
+++ b/src/matrix/room/timeline/persistence/TimelineReader.js
@@ -132,6 +132,23 @@ export class TimelineReader {
         }, log);
     }
 
+    async readById(id, log) {
+        let stores = [this._storage.storeNames.timelineEvents];
+        if (this.isEncrypted) {
+            stores.push(this._storage.storeNames.inboundGroupSessions);
+        }
+        const txn = await this._storage.readTxn(stores); // todo: can we just use this.readTxnStores here? probably
+        const storageEntry = await txn.timelineEvents.getByEventId(this._roomId, id);
+        if (storageEntry) {
+            const entry = new EventEntry(storageEntry, this._fragmentIdComparer);
+            if (this._decryptEntries) {
+                const request = this._decryptEntries([entry], txn, log);
+                await request.complete();
+            }
+            return entry;
+        }
+    }
+
     async _readFrom(eventKey, direction, amount, r, txn, log) {
         const entries = await readRawTimelineEntriesWithTxn(this._roomId, eventKey, direction, amount, this._fragmentIdComparer, txn);
         if (this._decryptEntries) {

--- a/src/mocks/event.js
+++ b/src/mocks/event.js
@@ -37,3 +37,13 @@ export function withTxnId(txnId, event) {
 export function withRedacts(redacts, reason, event) {
     return Object.assign({redacts, content: {reason}}, event);
 }
+
+export function withReply(replyToId, event) {
+    return withContent({
+        "m.relates_to": {
+            "m.in_reply_to": {
+                "event_id": replyToId
+            }
+        }
+    }, event);
+}


### PR DESCRIPTION
- [x] Create proper event-entries with event data fetched from hs
- [x] Decryption of event-entries created with data from hs
- [x] Display-name/avatar data with event-entries created with data from hs
- [ ] Log operations
## Overview:
- Implement context endpoint needed to fetch an event from hs
- Link every entry with its context-entry (taking care of things like updates)

## Terminologies / changes added to EventEntry:  

For a given `EventEntry` e:
- e.**contextEventId**: is the event-id of another event to which this event is a reply of.
- e.**contextEntry**: is the actual event-entry to which this event is a reply of.
- e.**contextForEntries**: = `{event| event.contextEntry = e}` i.e this is an array of event-entries such that for each event-entry in this array, *e* is its context.  
Used for propagating updates from a given entry to other entries that depend on it to render reply-previews; eg: if an entry is redacted, all other entries which use this entry as context for rendering reply preview must be notified (so that redaction can be rendered in reply previews).

## Terminologies / changes added to Timeline:  
- **contextEntriesNotInTimeline**: Is a Map of entries that were fetched from storage/hs because it was needed as a context for some other entry. They are fetched from storage/hs because they are currently not in the timeline( i.e not in remoteEntries ).
