### PR TITLE
Add hash-bang to fix sdk build error

### DIFF
--- a/scripts/sdk/build.sh
+++ b/scripts/sdk/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm -rf target
 yarn run vite build -c vite.sdk-assets-config.js
 yarn run vite build -c vite.sdk-lib-config.js


### PR DESCRIPTION
Without this change, the build failed and deleted everything in my hydrogen directory. 
The relevant bit of the error is:
```bash
./scripts/sdk/build.sh: 9: pushd: not found
./scripts/sdk/build.sh: 10: pushd: not found
```