### PR TITLE
Adjust SDK to not do asset imports anymore in file provided from SDK

### DIFF
--- a/doc/SDK.md
+++ b/doc/SDK.md
@@ -33,7 +33,20 @@ import {
     RoomViewModel,
     TimelineView
 } from "hydrogen-view-sdk";
-import assetPaths from "hydrogen-view-sdk/paths/vite";
+import downloadSandboxPath from 'hydrogen-view-sdk/download-sandbox.html?url';
+import workerPath from 'hydrogen-view-sdk/main.js?url';
+import olmWasmPath from '@matrix-org/olm/olm.wasm?url';
+import olmJsPath from '@matrix-org/olm/olm.js?url';
+import olmLegacyJsPath from '@matrix-org/olm/olm_legacy.js?url';
+const assetPaths = {
+    downloadSandbox: downloadSandboxPath,
+    worker: workerPath,
+    olm: {
+        wasm: olmWasmPath,
+        legacyBundle: olmLegacyJsPath,
+        wasmBundle: olmJsPath
+    }
+};
 import "hydrogen-view-sdk/style.css";
 
 async function main() {
@@ -84,7 +97,13 @@ main();
 
 ## Typescript support
 
-There is partial typescript support while we are still in the process of converting the Hydrogen codebase to typesccript.
+Typescript support is not yet available while we're converting the Hydrogen codebase to Typescript.
+In your `src` directory, you'll need to add a `.d.ts` (can be called anything, e.g. `deps.d.ts`)
+containing this snippet to make Typescript not complain that `hydrogen-view-sdk` doesn't have types:
+
+```ts
+declare module "hydrogen-view-sdk";
+```
 
 ## API Stability
 

--- a/scripts/sdk/build.sh
+++ b/scripts/sdk/build.sh
@@ -5,7 +5,8 @@ yarn run vite build -c vite.sdk-lib-config.js
 yarn tsc -p tsconfig-declaration.json
 ./scripts/sdk/create-manifest.js ./target/package.json
 mkdir target/paths
-./scripts/sdk/transform-paths.js ./src/platform/web/sdk/paths/vite.js ./target/paths/vite.js
+# this doesn't work, the ?url imports need to be in the consuming project, so disable for now
+# ./scripts/sdk/transform-paths.js ./src/platform/web/sdk/paths/vite.js ./target/paths/vite.js
 cp doc/SDK.md target/README.md
 pushd target
 pushd asset-build/assets


### PR DESCRIPTION
We need to do them from the consuming app, vite doesn't seem to support ?url imports from a module in a library, it needs to be from the app code itself that consumes the SDK.