### PR TITLE
remove enterkeyhint attribute as it prevents entering newlines on android

### DIFF
--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -30,7 +30,6 @@ export class MessageComposer extends TemplateView {
 
     render(t, vm) {
         this._input = t.textarea({
-            enterkeyhint: 'send',
             onKeydown: e => this._onKeyDown(e),
             onInput: () => {
                 vm.setInput(this._input.value);


### PR DESCRIPTION
Fixes https://github.com/vector-im/hydrogen-web/issues/636

on Android, by default (without the above attribute set to "send"), you
press enter twice to submit a field. The first time, enter, Android
seems to prevent sending logic by setting the key property on the event
to "Unidentified", but does insert a newline. The second consecutive enter,
it will be set to "Enter" and we'll send.

Having enterkeyhint to send will disable all of that. So we're going with
the default behaviour, which, IIRC, was a bit annoying on iOS as well.