### PR TITLE
Added: Dependabot & Dockerfile image tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Docs: <https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/customizing-dependency-updates>
+
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule: {interval: daily}
+
+  - package-ecosystem: docker
+    directory: /
+    schedule: {interval: daily}
+
+  - package-ecosystem: npm
+    directory: /
+    schedule: {interval: daily}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM docker.io/node:alpine as builder
+FROM docker.io/node:17.4.0-alpine as builder
 RUN apk add --no-cache git python3 build-base
 COPY . /app
 WORKDIR /app
 RUN yarn install \
  && yarn build
 
-FROM docker.io/nginx:alpine
+FROM docker.io/nginx:1.21.6-alpine
 COPY --from=builder /app/target /usr/share/nginx/html

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM docker.io/node:alpine
+FROM docker.io/node:17.4.0-alpine
 RUN apk add --no-cache git python3 build-base
 COPY . /code
 WORKDIR /code


### PR DESCRIPTION
I already use Dependabot for many projects. With Dependabot it is relatively easy to stay up to date with the dependencies and packages used. Instead of always checking for updates manually, you can use the dependabot.yml configuration to tell Dependabot to check the project once a week for new releases of e.g. the npm dependencies that are used or newer Docker image tags. If there are new updates, a new pull request is automatically created for them.

Since this procedure takes at least some work off my hands over at my projects, I wanted to ask if you would be up to using it as well.


I've also added versioned image tags to both Dockerfiles so we have more control over which tag we use in case a new version of Node breaks something on our end in the future