### PR TITLE
Docker image improvements

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1
         with:
@@ -39,6 +42,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,21 @@ RUN yarn install
 COPY . .
 RUN yarn build
 
+# Remove the default config, replace it with a symlink to somewhere that will be updated at runtime
+RUN rm -f target/config.json \
+    && ln -sf /tmp/config.json target/config.json
+
 FROM --platform=${TARGETPLATFORM} docker.io/nginxinc/nginx-unprivileged:1.21-alpine
+
+# Copy the config template as well as the templating script
+COPY ./docker/config.json.tmpl /config.json.tmpl
+COPY ./docker/config-template.sh /docker-entrypoint.d/99-config-template.sh
+
+# Copy the built app from the first build stage
 COPY --from=builder /app/target /usr/share/nginx/html
+
+# Values from the default config that can be overridden at runtime
+ENV PUSH_APP_ID="io.element.hydrogen.web" \
+    PUSH_GATEWAY_URL="https://matrix.org" \
+    PUSH_APPLICATION_SERVER_KEY="BC-gpSdVHEXhvHSHS0AzzWrQoukv2BE7KzpoPO_FfPacqOo3l1pdqz7rSgmB04pZCWaHPz7XRe6fjLaC-WPDopM" \
+    DEFAULT_HOMESERVER="matrix.org"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ RUN yarn install
 COPY . .
 RUN yarn build
 
-FROM --platform=${TARGETPLATFORM} docker.io/library/nginx:alpine
+FROM --platform=${TARGETPLATFORM} docker.io/nginxinc/nginx-unprivileged:1.21-alpine
 COPY --from=builder /app/target /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-FROM docker.io/node:alpine as builder
+FROM --platform=${BUILDPLATFORM} docker.io/library/node:16.13-alpine3.15 as builder
 RUN apk add --no-cache git python3 build-base
-COPY . /app
 WORKDIR /app
-RUN yarn install \
- && yarn build
 
-FROM docker.io/nginx:alpine
+# Install the dependencies first
+COPY yarn.lock package.json ./
+RUN yarn install
+
+# Copy the rest and build the app
+COPY . .
+RUN yarn build
+
+FROM --platform=${TARGETPLATFORM} docker.io/library/nginx:alpine
 COPY --from=builder /app/target /usr/share/nginx/html

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -55,6 +55,6 @@ Then, start up a container from that image:
 ```
 docker run \
     --name hydrogen \
-    --publish 80:80 \
+    --publish 8080:80 \
     hydrogen
 ```

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -35,7 +35,9 @@ To stop the container, simply hit `ctrl+c`.
 
 In this repository, create a Docker image:
 
-```
+```sh
+# Enable BuildKit https://docs.docker.com/develop/develop-images/build_enhancements/
+export DOCKER_BUILDKIT=1
 docker build -t hydrogen .
 ```
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -41,11 +41,11 @@ export DOCKER_BUILDKIT=1
 docker build -t hydrogen .
 ```
 
-Or, pull the docker image from GitLab:
+Or, pull the Docker image the GitHub Container Registry:
 
 ```
-docker pull registry.gitlab.com/jcgruenhage/hydrogen-web
-docker tag registry.gitlab.com/jcgruenhage/hydrogen-web hydrogen
+docker pull ghcr.io/vector-im/hydrogen
+docker tag ghcr.io/vector-im/hydrogen hydrogen
 ```
 
 ### Start container image

--- a/docker/config-template.sh
+++ b/docker/config-template.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux
+
+envsubst '$PUSH_APP_ID,$PUSH_GATEWAY_URL,$PUSH_APPLICATION_SERVER_KEY,$DEFAULT_HOMESERVER' \
+    < /config.json.tmpl \
+    > /tmp/config.json

--- a/docker/config.json.tmpl
+++ b/docker/config.json.tmpl
@@ -1,0 +1,8 @@
+{
+    "push": {
+        "appId": "$PUSH_APP_ID",
+        "gatewayUrl": "$PUSH_GATEWAY_URL",
+        "applicationServerKey": "$PUSH_APPLICATION_SERVER_KEY"
+    },
+    "defaultHomeServer": "$DEFAULT_HOMESERVER"
+}


### PR DESCRIPTION
The commits are individually reviewable. This includes:

 - the docker image is now multi-arch capable thanks to BuildKit. It does not rely on QEMU emulation, rather using BuildKit's `TARGETPLATFORM` and `BUILDPLATFORM` build args for doing the bundling under the host arch
 - use an unprivileged nginx base image to run as non-root. This also allows running the whole thing with a read-only root filesystem. It still needs a writable `/tmp`, e.g. `docker run --publish 80:8080 --read-only --volume tmp:/tmp hydrogen`
 - have the CI build a multi-arch image (currently building for x86_64, ARM and ARM64)
 - some updates to the documentation
 - a `config.json` templated from environment variables