### PR TITLE
Draft: PoC Render to string

### DIFF
--- a/src/platform/web/ui/general/ListView.ts
+++ b/src/platform/web/ui/general/ListView.ts
@@ -81,7 +81,7 @@ export class ListView<T, V extends IView> implements IView, IListObserver<T> {
         const root = this._root = el(this._tagName, attr);
         this.loadList();
         if (this._onItemClick) {
-            root.addEventListener("click", this);
+            //root.addEventListener("click", this);
         }
         return root;
     }

--- a/src/platform/web/ui/general/TemplateView.ts
+++ b/src/platform/web/ui/general/TemplateView.ts
@@ -292,6 +292,11 @@ export class TemplateBuilder<T extends IObservableValue> {
         const attrMap = {};
         if(attributes) {
             for(let [key, value] of Object.entries(attributes)) {
+                let attrName = key;
+                if (key === "className") {
+                    attrName = "class";
+                }
+
                 // binding for className as object of className => enabled
                 if (typeof value === "object") {
                     if (key !== "className" || value === null) {
@@ -300,16 +305,17 @@ export class TemplateBuilder<T extends IObservableValue> {
                     }
                     if (objHasFns(value)) {
                         //this._addClassNamesBinding(node, value);
-                        attrMap[key] = classNames(value, value);
+                        attrMap[attrName] = classNames(value, value);
                     } else {
-                        attrMap[key] = classNames(value, this._value);
+                        attrMap[attrName] = classNames(value, this._value);
                     }
                 } else if (this._isEventHandler(key, value)) {
                     // no-op
                 } else if (typeof value === "function") {
-                    this._addAttributeBinding(node, key, value);
+                    //this._addAttributeBinding(node, key, value);
+                    attrMap[attrName] = value(this._value);
                 } else {
-                    attrMap[key] = value;
+                    attrMap[attrName] = value;
                 }
             }
         }

--- a/src/platform/web/ui/general/html.ts
+++ b/src/platform/web/ui/general/html.ts
@@ -60,12 +60,34 @@ export function el(elementName: string, attributes?: BasicAttributes<never> | Ch
 }
 
 export function elNS(ns: string, elementName: string, attributes?: BasicAttributes<never> | Child | Child[], children?: Child | Child[]): Element {
+    //console.log('html elNS', new Error().stack);
     if (attributes && isChildren(attributes)) {
         children = attributes;
         attributes = undefined;
     }
 
     const e = document.createElementNS(ns, elementName);
+
+    const attrMap = {};
+    if (attributes) {
+        for (let [name, value] of Object.entries(attributes)) {
+            if (typeof value === "object") {
+                // Only className should ever be an object; be careful
+                // here anyway and ignore object-valued non-className attributes.
+                value = (value !== null && name === "className") ? classNames(value, undefined) : false;
+            }
+            attrMap[name] = value;
+        }
+    }
+
+    const attrString = Object.keys(attrMap)
+        .map((attrKey) => {
+            return `${attrKey}="${attrMap[attrKey]}"`;
+        })
+        .join(' ');
+
+    return `<${elementName} ${attrString}>${[].concat(children).join('')}</${elementName}>`;
+
 
     if (attributes) {
         for (let [name, value] of Object.entries(attributes)) {
@@ -93,7 +115,8 @@ export function elNS(ns: string, elementName: string, attributes?: BasicAttribut
 }
 
 export function text(str: string): Text {
-    return document.createTextNode(str);
+    return str;
+    //return document.createTextNode(str);
 }
 
 export const HTML_NS: string = "http://www.w3.org/1999/xhtml";

--- a/src/platform/web/ui/session/room/TimelineView.ts
+++ b/src/platform/web/ui/session/room/TimelineView.ts
@@ -57,16 +57,34 @@ export class TimelineView extends TemplateView<TimelineViewModel> {
 
     render(t: Builder<TimelineViewModel>, vm: TimelineViewModel) {
         // assume this view will be mounted in the parent DOM straight away
-        requestAnimationFrame(() => {
-            // do initial scroll positioning
-            this.restoreScrollPosition();
-        });
+        // requestAnimationFrame(() => {
+        //     // do initial scroll positioning
+        //     this.restoreScrollPosition();
+        // });
+        console.log('vm.tiles', vm.tiles)
+
+        const childrenRenders = [];
+        for(const entry of vm.tiles) {
+            const View = viewClassForEntry(entry);
+            if (View) {
+                const view = new View(entry);
+                const childrenRender = view.render(t, entry);
+                console.log('childrenRender', childrenRender)
+                childrenRenders.push(childrenRender);
+                //childrenViews.push();
+            }
+        }
+
         this.tilesView = new TilesListView(vm.tiles, () => this.restoreScrollPosition());
         const root = t.div({className: "Timeline"}, [
-            t.div({
-                className: "Timeline_scroller bottom-aligned-scroll",
-                onScroll: () => this.onScroll()
-            }, t.view(this.tilesView)),
+            t.div(
+                {
+                    className: "Timeline_scroller bottom-aligned-scroll",
+                    onScroll: () => this.onScroll()
+                },
+                //t.view(this.tilesView)
+                childrenRenders
+            ),
             t.button({
                 className: {
                     "Timeline_jumpDown": true,
@@ -77,12 +95,12 @@ export class TimelineView extends TemplateView<TimelineViewModel> {
             })
         ]);
 
-        if (typeof ResizeObserver === "function") {
-            this.resizeObserver = new ResizeObserver(() => {
-                this.restoreScrollPosition();
-            });
-            this.resizeObserver.observe(root);
-        }
+        // if (typeof ResizeObserver === "function") {
+        //     this.resizeObserver = new ResizeObserver(() => {
+        //         this.restoreScrollPosition();
+        //     });
+        //     this.resizeObserver.observe(root);
+        // }
 
         return root;
     }

--- a/src/platform/web/ui/session/room/timeline/TextMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/TextMessageView.js
@@ -21,26 +21,36 @@ import {ReplyPreviewError, ReplyPreviewView} from "./ReplyPreviewView.js";
 export class TextMessageView extends BaseMessageView {
     renderMessageBody(t, vm) {
         const time = t.time({className: {hidden: !vm.date}}, vm.date + " " + vm.time);
-        const container = t.div({
-            className: {
-                "Timeline_messageBody": true,
-                statusMessage: vm => vm.shape === "message-status",
-            }
-        }, t.mapView(vm => vm.replyTile, replyTile => {
-            if (this._isReplyPreview) {
-                // if this._isReplyPreview = true, this is already a reply preview, don't nest replies for now.
-                return null;
-            }
-            else if (vm.isReply && !replyTile) {
-                return new ReplyPreviewError();
-            }
-            else if (replyTile) {
-                return new ReplyPreviewView(replyTile);
-            }
-            else {
-                return null;
-            }
-        }));
+
+        const parts = [];
+        for (const part of vm.body.parts) {
+            parts.push(renderPart(part));
+        }
+
+        const container = t.div(
+            {
+                className: {
+                    "Timeline_messageBody": true,
+                    statusMessage: vm => vm.shape === "message-status",
+                }
+            },
+            parts,
+            // t.mapView(vm => vm.replyTile, replyTile => {
+            //     if (this._isReplyPreview) {
+            //         // if this._isReplyPreview = true, this is already a reply preview, don't nest replies for now.
+            //         return null;
+            //     }
+            //     else if (vm.isReply && !replyTile) {
+            //         return new ReplyPreviewError();
+            //     }
+            //     else if (replyTile) {
+            //         return new ReplyPreviewView(replyTile);
+            //     }
+            //     else {
+            //         return null;
+            //     }
+            // })
+        );
 
         const shouldRemove = (element) => element?.nodeType === Node.ELEMENT_NODE && element.className !== "ReplyPreviewView";
 
@@ -53,6 +63,9 @@ export class TextMessageView extends BaseMessageView {
             }
             container.appendChild(time);
         });
+
+        
+        
 
         return container;
     }


### PR DESCRIPTION
Just some proof of concept work to see if `renderToString` would be possible to facilitate server-side rendering.

Please ignore.

Related to https://github.com/vector-im/hydrogen-web/pull/653


It sorta works:

What it looks like from https://github.com/vector-im/hydrogen-web/pull/653 (expected) | This PR (actual)
--- | ---
![](https://user-images.githubusercontent.com/558581/152294184-acd9e141-5959-45a5-8712-206915cd21f1.png) | ![](https://user-images.githubusercontent.com/558581/152294179-987d2149-fe64-4c97-b751-001b877d7863.png)






## Dev notes

```js
const view = new TimelineView(timelineViewModel);
// view.mount() now returns a string of HTML
app.insertAdjacentHTML('beforeend', view.mount());
```

### Problems

 - Some `render()` functions have DOM side-effects
 - `t.view(...)` causes a lot of side-effects since it calls `mount()` (which has side-effects), then `render()`
    - In my use, the `ListView` which is an `IView` and does a bunch of `mount` `document.appendChild` stuff
    - A `TemplateView` is much more compatible since we can just render and get a string mostly