### PR TITLE
Runtime configuration without rebuilding the app

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v1
         with:
@@ -39,6 +42,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ RUN yarn install
 COPY . .
 RUN yarn build
 
-FROM --platform=${TARGETPLATFORM} docker.io/library/nginx:alpine
+FROM --platform=${TARGETPLATFORM} docker.io/nginxinc/nginx-unprivileged:1.21-alpine
 COPY --from=builder /app/target /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-FROM docker.io/node:alpine as builder
+FROM --platform=${BUILDPLATFORM} docker.io/library/node:16.13-alpine3.15 as builder
 RUN apk add --no-cache git python3 build-base
-COPY . /app
 WORKDIR /app
-RUN yarn install \
- && yarn build
 
-FROM docker.io/nginx:alpine
+# Install the dependencies first
+COPY yarn.lock package.json ./
+RUN yarn install
+
+# Copy the rest and build the app
+COPY . .
+RUN yarn build
+
+FROM --platform=${TARGETPLATFORM} docker.io/library/nginx:alpine
 COPY --from=builder /app/target /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,21 @@ RUN yarn install
 COPY . .
 RUN yarn build
 
+# Remove the default config, replace it with a symlink to somewhere that will be updated at runtime
+RUN rm -f target/config.js \
+    && ln -sf /tmp/config.js target/config.js
+
 FROM --platform=${TARGETPLATFORM} docker.io/nginxinc/nginx-unprivileged:1.21-alpine
+
+# Copy the config template as well as the templating script
+COPY ./docker/config.js.tmpl /config.js.tmpl
+COPY ./docker/config-template.sh /docker-entrypoint.d/99-config-template.sh
+
+# Copy the built app from the first build stage
 COPY --from=builder /app/target /usr/share/nginx/html
+
+# Values from the default config that can be overridden at runtime
+ENV PUSH_APP_ID="io.element.hydrogen.web" \
+    PUSH_GATEWAY_URL="https://matrix.org" \
+    PUSH_APPLICATION_SERVER_KEY="BC-gpSdVHEXhvHSHS0AzzWrQoukv2BE7KzpoPO_FfPacqOo3l1pdqz7rSgmB04pZCWaHPz7XRe6fjLaC-WPDopM" \
+    DEFAULT_HOMESERVER="matrix.org"

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -55,6 +55,6 @@ Then, start up a container from that image:
 ```
 docker run \
     --name hydrogen \
-    --publish 80:80 \
+    --publish 8080:80 \
     hydrogen
 ```

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -35,7 +35,9 @@ To stop the container, simply hit `ctrl+c`.
 
 In this repository, create a Docker image:
 
-```
+```sh
+# Enable BuildKit https://docs.docker.com/develop/develop-images/build_enhancements/
+export DOCKER_BUILDKIT=1
 docker build -t hydrogen .
 ```
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -41,11 +41,11 @@ export DOCKER_BUILDKIT=1
 docker build -t hydrogen .
 ```
 
-Or, pull the docker image from GitLab:
+Or, pull the Docker image the GitHub Container Registry:
 
 ```
-docker pull registry.gitlab.com/jcgruenhage/hydrogen-web
-docker tag registry.gitlab.com/jcgruenhage/hydrogen-web hydrogen
+docker pull ghcr.io/vector-im/hydrogen
+docker tag ghcr.io/vector-im/hydrogen hydrogen
 ```
 
 ### Start container image

--- a/docker/config-template.sh
+++ b/docker/config-template.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux
+
+envsubst '$PUSH_APP_ID,$PUSH_GATEWAY_URL,$PUSH_APPLICATION_SERVER_KEY,$DEFAULT_HOMESERVER' \
+    < /config.js.tmpl \
+    > /tmp/config.js

--- a/docker/config.js.tmpl
+++ b/docker/config.js.tmpl
@@ -1,0 +1,9 @@
+window.APP_CONFIG = {
+    push: {
+        appId: "$PUSH_APP_ID",
+        gatewayUrl: "$PUSH_GATEWAY_URL",
+        applicationServerKey: "$PUSH_APPLICATION_SERVER_KEY"
+    },
+    defaultHomeServer: "$DEFAULT_HOMESERVER"
+};
+

--- a/src/platform/web/assets/config.json
+++ b/src/platform/web/assets/config.json
@@ -1,8 +1,0 @@
-{
-  "push": {
-    "appId": "io.element.hydrogen.web",
-    "gatewayUrl": "https://matrix.org",
-    "applicationServerKey": "BC-gpSdVHEXhvHSHS0AzzWrQoukv2BE7KzpoPO_FfPacqOo3l1pdqz7rSgmB04pZCWaHPz7XRe6fjLaC-WPDopM"
-  },
-  "defaultHomeServer": "matrix.org"
-}

--- a/src/platform/web/index.html
+++ b/src/platform/web/index.html
@@ -9,6 +9,7 @@
         <meta name="apple-mobile-web-app-status-bar-style" content="black">
         <meta name="apple-mobile-web-app-title" content="Hydrogen Chat">
         <meta name="description" content="A matrix chat application">
+        <script src="config.js"></script>
         <link rel="apple-touch-icon" href="./assets/icon-maskable.png">
         <link rel="icon" type="image/png" href="assets/icon-maskable.png">
         <link rel="stylesheet" type="text/css" href="./ui/css/main.css">
@@ -18,7 +19,6 @@
         <script id="main" type="module">
             import {main} from "./main";
             import {Platform} from "./Platform";
-            import configJSON from "./assets/config.json?raw";
             import assetPaths from "./sdk/paths/vite";
             if (import.meta.env.PROD) {
                 assetPaths.serviceWorker = "sw.js";
@@ -26,7 +26,7 @@
             const platform = new Platform(
                 document.body,
                 assetPaths,
-                JSON.parse(configJSON),
+                window.APP_CONFIG || {},
                 {development: import.meta.env.DEV}
             );
             main(platform);

--- a/src/platform/web/public/config.js
+++ b/src/platform/web/public/config.js
@@ -1,0 +1,8 @@
+window.APP_CONFIG = {
+    push: {
+        appId: "io.element.hydrogen.web",
+        gatewayUrl: "https://matrix.org",
+        applicationServerKey: "BC-gpSdVHEXhvHSHS0AzzWrQoukv2BE7KzpoPO_FfPacqOo3l1pdqz7rSgmB04pZCWaHPz7XRe6fjLaC-WPDopM"
+    },
+    defaultHomeServer: "matrix.org"
+};

--- a/vite.common-config.js
+++ b/vite.common-config.js
@@ -7,7 +7,6 @@ const version = manifest.version;
 
 const commonOptions = {
     logLevel: "warn",
-    publicDir: false,
     server: {
         hmr: false
     },


### PR DESCRIPTION
This sits on top of #655. Compare view until it is merged: https://github.com/sandhose/hydrogen-web/compare/sandhose/runtime-config...sandhose:sandhose/runtime-config-2

For context: https://github.com/vector-im/hydrogen-web/pull/655#issuecomment-1041215674

@bwindels let me know if I should try something else, like `fetch`ing a JSON file on startup instead of injecting the config in `window`.