### PR TITLE
Add more HTML form and SVG elements

### DIFF
--- a/src/platform/web/ui/general/html.ts
+++ b/src/platform/web/ui/general/html.ts
@@ -104,8 +104,9 @@ export const TAG_NAMES = {
         "br", "a", "ol", "ul", "li", "div", "h1", "h2", "h3", "h4", "h5", "h6",
         "p", "strong", "em", "span", "img", "section", "main", "article", "aside", "del", "blockquote",
         "table", "thead", "tbody", "tr", "th", "td", "hr",
-        "pre", "code", "button", "time", "input", "textarea", "label", "form", "progress", "output", "video"],
-    [SVG_NS]: ["svg", "circle"]
+        "pre", "code", "button", "time", "input", "textarea", "select", "option", "label", "form",
+        "progress", "output", "video"],
+    [SVG_NS]: ["svg", "g", "path", "circle", "ellipse", "rect", "use"]
 } as const;
 
 export const tag: { [tagName in typeof TAG_NAMES[string][number]]: (attributes?: BasicAttributes<never> | Child | Child[], children?: Child | Child[]) => Element } = {} as any;


### PR DESCRIPTION
Add more HTML form and SVG elements

Split off from https://github.com/vector-im/hydrogen-web/pull/653

Personally using `select`, `option`, and `path` currently in https://github.com/matrix-org/matrix-public-archive
but added a few extra SVG elements that seemed common to me.