### PR TITLE
Only initialize `Crypto` when olm is provided

### DIFF
--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -143,7 +143,10 @@ export class Platform {
             this._serviceWorkerHandler.registerAndStart(assetPaths.serviceWorker);
         }
         this.notificationService = new NotificationService(this._serviceWorkerHandler, config.push);
-        this.crypto = new Crypto(cryptoExtras);
+        // `window.crypto.subtle` is only available in a secure context
+        if(window.isSecureContext) {
+            this.crypto = new Crypto(cryptoExtras);
+        }
         this.storageFactory = new StorageFactory(this._serviceWorkerHandler);
         this.sessionInfoStorage = new SessionInfoStorage("hydrogen_sessions_v1");
         this.estimateStorageUsage = estimateStorageUsage;

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -143,8 +143,8 @@ export class Platform {
             this._serviceWorkerHandler.registerAndStart(assetPaths.serviceWorker);
         }
         this.notificationService = new NotificationService(this._serviceWorkerHandler, config.push);
-        // `window.crypto.subtle` is only available in a secure context
-        if(window.isSecureContext) {
+        // Only try to use crypto when olm is provided
+        if(this._assetPaths.olm) {
             this.crypto = new Crypto(cryptoExtras);
         }
         this.storageFactory = new StorageFactory(this._serviceWorkerHandler);


### PR DESCRIPTION
Only initialize `Crypto` when olm is provided.

Split out from https://github.com/vector-im/hydrogen-web/pull/653

As a note, `window.crypto.subtle` is only avaialble in secure contexts(`window.isSecureContext`). Relevant error if you crypto is used in a non-secure context like a local LAN IP `http://192.168.1.151:3050/`
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'deriveBits')
	at new Crypto
	at new Platform
	at mountHydrogen
```

For my use-case with https://github.com/matrix-org/matrix-public-archive, I don't need crypto/encryption at all so if there was a way to completely disable, that would be even better. Related to https://github.com/vector-im/hydrogen-web/issues/579



---

Docs:

 - https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
 - https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle
    - "Secure context: This feature is available only in secure contexts (HTTPS), in some or all supporting browsers."


