### PR TITLE
Add observeNavigation in ViewModel

### DIFF
--- a/src/domain/ViewModel.ts
+++ b/src/domain/ViewModel.ts
@@ -58,9 +58,9 @@ export class ViewModel<O extends Options = Options> extends EventEmitter<{change
         return this._options[name];
     }
 
-    observeNavigation(type: string, onChange: (value: true | string, type: string) => void) {
+    observeNavigation(type: string, onChange: (value: string | true | undefined, type: string) => void) {
       const segmentObservable = this.navigation.observe(type);
-      const unsubscribe = segmentObservable.subscribe((value: true | string) => {
+      const unsubscribe = segmentObservable.subscribe((value: string | true | undefined) => {
         onChange(value, type);
       })
       this.track(unsubscribe);

--- a/src/domain/ViewModel.ts
+++ b/src/domain/ViewModel.ts
@@ -58,6 +58,14 @@ export class ViewModel<O extends Options = Options> extends EventEmitter<{change
         return this._options[name];
     }
 
+    observeNavigation(type: string, onChange: (value: true | string, type: string) => void) {
+      const segmentObservable = this.navigation.observe(type);
+      const unsubscribe = segmentObservable.subscribe((value: true | string) => {
+        onChange(value, type);
+      })
+      this.track(unsubscribe);
+    }
+
     track<D extends Disposable>(disposable: D): D {
         if (!this.disposables) {
             this.disposables = new Disposables();


### PR DESCRIPTION
These changes added observeNavigation method in ViewModel class to help observe navigation without adding much boilerplate code in view models.