### PR TITLE
Fix asset build throwing and swallowing errors

### DIFF
--- a/scripts/postcss/css-url-processor.js
+++ b/scripts/postcss/css-url-processor.js
@@ -39,7 +39,7 @@ function colorsFromURL(url, colorMap) {
 function processURL(decl, replacer, colorMap) {
     const value = decl.value;
     const parsed = valueParser(value);
-    parsed.walk(async node => {
+    parsed.walk(node => {
         if (node.type !== "function" || node.value !== "url") {
             return;
         }

--- a/scripts/postcss/svg-colorizer.js
+++ b/scripts/postcss/svg-colorizer.js
@@ -37,7 +37,7 @@ module.exports.buildColorizedSVG = function (svgLocation, primaryColor, secondar
     if (svgCode === coloredSVGCode) {
         throw new Error("svg-colorizer made no color replacements! The input svg should only contain colors #ff00ff (primary, case-sensitive) and #00ffff (secondary, case-sensitive).");
     }
-    const fileName = svgLocation.match(/.+\/(.+\.svg)/)[1];
+    const fileName = svgLocation.match(/.+[/\\](.+\.svg)/)[1];
     const outputName = `${fileName.substring(0, fileName.length - 4)}-${createHash(coloredSVGCode)}.svg`;
     const outputPath = path.resolve(__dirname, "../../.tmp");
     try {

--- a/scripts/sdk/build.sh
+++ b/scripts/sdk/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Exit whenever one of the commands fail with a non-zero exit code
+set -e
+set -o pipefail
+
 rm -rf target
 yarn run vite build -c vite.sdk-assets-config.js
 yarn run vite build -c vite.sdk-lib-config.js


### PR DESCRIPTION
Fix asset build throwing and swallowing errors

 - Fix `svg-colorizer` throwing errors with Windows file paths
 - Fix `css-url-parser` swallowing errors because it was `async`
 - Fail SDK build script (`yarn build:sdk`, `build.sh`) overall when some commands are failing