### PR TITLE
Read config.json on app start

### DIFF
--- a/src/platform/web/LegacyPlatform.js
+++ b/src/platform/web/LegacyPlatform.js
@@ -19,6 +19,6 @@ import {hkdf} from "../../utils/crypto/hkdf";
 
 import {Platform as ModernPlatform} from "./Platform.js";
 
-export function Platform(container, assetPaths, config, options = null) {
-    return new ModernPlatform(container, assetPaths, config, options, {aesjs, hkdf});
+export function Platform({ container, assetPaths, config, configURL, options = null }) {
+    return new ModernPlatform({ container, assetPaths, config, configURL, options, cryptoExtras: { aesjs, hkdf }});
 }

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -171,7 +171,7 @@ export class Platform {
             if (!this._configURL) {
                 throw new Error("Neither config nor configURL was provided!");
             }
-            const {body}= await this.request(this._configURL, {method: "GET", format: "json"}).response();
+            const {body}= await this.request(this._configURL, {method: "GET", format: "json", cache: true}).response();
             this._config = body;
         }
         this._notificationService = new NotificationService(

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -126,7 +126,7 @@ function adaptUIOnVisualViewportResize(container) {
 }
 
 export class Platform {
-    constructor(container, assetPaths, config, options = null, cryptoExtras = null) {
+    constructor({ container, assetPaths, config, options = null, cryptoExtras = null }) {
         this._container = container;
         this._assetPaths = assetPaths;
         this._config = config;

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -126,10 +126,11 @@ function adaptUIOnVisualViewportResize(container) {
 }
 
 export class Platform {
-    constructor({ container, assetPaths, config, options = null, cryptoExtras = null }) {
+    constructor({ container, assetPaths, config, configURL, options = null, cryptoExtras = null }) {
         this._container = container;
         this._assetPaths = assetPaths;
         this._config = config;
+        this._configURL = configURL;
         this.settingsStorage = new SettingsStorage("hydrogen_setting_v1_");
         this.clock = new Clock();
         this.encoding = new Encoding();
@@ -142,7 +143,7 @@ export class Platform {
             this._serviceWorkerHandler = new ServiceWorkerHandler();
             this._serviceWorkerHandler.registerAndStart(assetPaths.serviceWorker);
         }
-        this.notificationService = new NotificationService(this._serviceWorkerHandler, config.push);
+        this.notificationService = null;
         // Only try to use crypto when olm is provided
         if(this._assetPaths.olm) {
             this.crypto = new Crypto(cryptoExtras);
@@ -163,6 +164,20 @@ export class Platform {
         this._disposables = new Disposables();
         this._olmPromise = undefined;
         this._workerPromise = undefined;
+    }
+
+    async init() {
+        if (!this._config) {
+            if (!this._configURL) {
+                throw new Error("Neither config nor configURL was provided!");
+            }
+            const {body}= await this.request(this._configURL, {method: "GET", format: "json"}).response();
+            this._config = body;
+        }
+        this._notificationService = new NotificationService(
+            this._serviceWorkerHandler,
+            this._config.push
+        );
     }
 
     _createLogger(isDevelopment) {

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -143,7 +143,7 @@ export class Platform {
             this._serviceWorkerHandler = new ServiceWorkerHandler();
             this._serviceWorkerHandler.registerAndStart(assetPaths.serviceWorker);
         }
-        this.notificationService = null;
+        this.notificationService = undefined;
         // Only try to use crypto when olm is provided
         if(this._assetPaths.olm) {
             this.crypto = new Crypto(cryptoExtras);

--- a/src/platform/web/index.html
+++ b/src/platform/web/index.html
@@ -17,7 +17,7 @@
         <script id="main" type="module">
             import {main} from "./main";
             import {Platform} from "./Platform";
-            import configJSON from "./assets/config.json?raw";
+            import configURL from "./assets/config.json?url";
             import assetPaths from "./sdk/paths/vite";
             if (import.meta.env.PROD) {
                 assetPaths.serviceWorker = "sw.js";
@@ -25,10 +25,9 @@
             const platform = new Platform({
                 container: document.body,
                 assetPaths,
-                config: JSON.parse(configJSON),
+                configURL, 
                 options: {development: import.meta.env.DEV}
-            }
-            );
+            });
             main(platform);
         </script>
     </body>

--- a/src/platform/web/index.html
+++ b/src/platform/web/index.html
@@ -22,11 +22,12 @@
             if (import.meta.env.PROD) {
                 assetPaths.serviceWorker = "sw.js";
             }
-            const platform = new Platform(
-                document.body,
+            const platform = new Platform({
+                container: document.body,
                 assetPaths,
-                JSON.parse(configJSON),
-                {development: import.meta.env.DEV}
+                config: JSON.parse(configJSON),
+                options: {development: import.meta.env.DEV}
+            }
             );
             main(platform);
         </script>

--- a/src/platform/web/main.js
+++ b/src/platform/web/main.js
@@ -32,6 +32,7 @@ export async function main(platform) {
         // const recorder = new RecordRequester(createFetchRequest(clock.createTimeout));
         // const request = recorder.request;
         // window.getBrawlFetchLog = () => recorder.log();
+        await platform.init();
         const navigation = createNavigation();
         platform.setNavigation(navigation);
         const urlRouter = createRouter({navigation, history: platform.history});

--- a/src/platform/web/sw.js
+++ b/src/platform/web/sw.js
@@ -75,11 +75,7 @@ self.addEventListener('fetch', (event) => {
     This has to do with xhr not being supported in service workers.
     */
     if (event.request.method === "GET") {
-        if (event.request.url.includes("config.json")) {
-            event.respondWith(handleConfigRequest(event.request));
-        } else {
-            event.respondWith(handleRequest(event.request));
-        }
+        event.respondWith(handleRequest(event.request));
     }
 });
 
@@ -96,8 +92,12 @@ function isCacheableThumbnail(url) {
 
 const baseURL = new URL(self.registration.scope);
 let pendingFetchAbortController = new AbortController();
+
 async function handleRequest(request) {
     try {
+        if (request.url.includes("config.json")) {
+            return handleConfigRequest(request);
+        }
         const url = new URL(request.url);
         // rewrite / to /index.html so it hits the cache
         if (url.origin === baseURL.origin && url.pathname === baseURL.pathname) {

--- a/src/platform/web/sw.js
+++ b/src/platform/web/sw.js
@@ -96,7 +96,7 @@ let pendingFetchAbortController = new AbortController();
 async function handleRequest(request) {
     try {
         if (request.url.includes("config.json")) {
-            return handleConfigRequest(request);
+            return await handleConfigRequest(request);
         }
         const url = new URL(request.url);
         // rewrite / to /index.html so it hits the cache

--- a/src/platform/web/sw.js
+++ b/src/platform/web/sw.js
@@ -125,12 +125,12 @@ async function handleRequest(request) {
 
 async function handleConfigRequest(request) {
     let response = await readCache(request);
+    const networkResponsePromise = fetchAndUpdateConfig(request);
     if (response) {
-        fetchAndUpdateConfig(request);
         return response;
+    } else {
+        return await networkResponsePromise;
     }
-    response = await fetchAndUpdateConfig(request);
-    return response;
 }
 
 async function fetchAndUpdateConfig(request) {

--- a/src/platform/web/sw.js
+++ b/src/platform/web/sw.js
@@ -96,7 +96,7 @@ let pendingFetchAbortController = new AbortController();
 async function handleRequest(request) {
     try {
         if (request.url.includes("config.json")) {
-            return await handleConfigRequest(request);
+            return handleConfigRequest(request);
         }
         const url = new URL(request.url);
         // rewrite / to /index.html so it hits the cache

--- a/src/platform/web/sw.js
+++ b/src/platform/web/sw.js
@@ -124,11 +124,6 @@ async function handleRequest(request) {
 }
 
 async function handleConfigRequest(request) {
-    const url = new URL(request.url);
-    // rewrite / to /index.html so it hits the cache
-    if (url.origin === baseURL.origin && url.pathname === baseURL.pathname) {
-        request = new Request(new URL("index.html", baseURL.href));
-    }
     let response = await readCache(request);
     if (response) {
         fetchAndUpdateConfig(request);

--- a/src/platform/web/sw.js
+++ b/src/platform/web/sw.js
@@ -76,9 +76,6 @@ self.addEventListener('fetch', (event) => {
     */
     if (event.request.method === "GET") {
         if (event.request.url.includes("config.json")) {
-            /**
-             * Use a different strategy for this file.
-             */
             event.respondWith(handleConfigRequest(event.request));
         } else {
             event.respondWith(handleRequest(event.request));

--- a/vite.common-config.js
+++ b/vite.common-config.js
@@ -31,6 +31,7 @@ const commonOptions = {
         assetsInlineLimit: 0,
         polyfillModulePreload: false,
     },
+    assetsInclude: ['**/config.json'],
     define: {
         DEFINE_VERSION: JSON.stringify(version),
         DEFINE_GLOBAL_HASH: JSON.stringify(null),

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,11 @@ export default defineConfig(({mode}) => {
             outDir: "../../../target",
             minify: true,
             sourcemap: true,
+            rollupOptions: {
+                output: {
+                    assetFileNames: (asset) => asset.name.includes("config.json") ? "assets/[name][extname]": "assets/[name].[hash][extname]",
+                },
+            },
         },
         plugins: [
             themeBuilder({


### PR DESCRIPTION
For #609;
- Platform ctor optionally accepts a config URL which is read in `init()`
-  Has vite-config changes to produce config.json during build
-  Special caching strategy for config.json