### PR TITLE
Newly created tiles must be given a copy of tilesOptions

### DIFF
--- a/src/domain/ViewModel.ts
+++ b/src/domain/ViewModel.ts
@@ -40,9 +40,9 @@ export type Options = {
 export class ViewModel<O extends Options = Options> extends EventEmitter<{change: never}> {
     private disposables?: Disposables;
     private _isDisposed = false;
-    private _options: O;
+    private _options: Readonly<O>;
 
-    constructor(options: O) {
+    constructor(options: Readonly<O>) {
         super();
         this._options = options;
     }
@@ -51,7 +51,7 @@ export class ViewModel<O extends Options = Options> extends EventEmitter<{change
         return Object.assign({}, this._options, explicitOptions);
     }
 
-    get options(): O { return this._options; }
+    get options(): Readonly<O> { return this._options; }
 
     // makes it easier to pass through dependencies of a sub-view model
     getOption<N extends keyof O>(name: N): O[N]  {

--- a/src/domain/ViewModel.ts
+++ b/src/domain/ViewModel.ts
@@ -115,10 +115,6 @@ export class ViewModel<O extends Options = Options> extends EventEmitter<{change
         return result;
     }
 
-    updateOptions(options: O): void {
-        this._options = Object.assign(this._options, options);
-    }
-
     emitChange(changedProps: any): void {
         if (this._options.emitChange) {
             this._options.emitChange(changedProps);

--- a/src/domain/session/room/timeline/TilesCollection.js
+++ b/src/domain/session/room/timeline/TilesCollection.js
@@ -35,7 +35,7 @@ export class TilesCollection extends BaseObservableList {
     _createTile(entry) {
         const Tile = this._tileOptions.tileClassForEntry(entry);
         if (Tile) {
-            return new Tile(entry, this._tileOptions);
+            return new Tile(entry, { ...this._tileOptions });
         }
     }
 

--- a/src/domain/session/room/timeline/TilesCollection.js
+++ b/src/domain/session/room/timeline/TilesCollection.js
@@ -35,7 +35,7 @@ export class TilesCollection extends BaseObservableList {
     _createTile(entry) {
         const Tile = this._tileOptions.tileClassForEntry(entry);
         if (Tile) {
-            return new Tile(entry, { ...this._tileOptions });
+            return new Tile(entry, this._tileOptions);
         }
     }
 

--- a/src/domain/session/room/timeline/tiles/SimpleTile.js
+++ b/src/domain/session/room/timeline/tiles/SimpleTile.js
@@ -22,6 +22,7 @@ export class SimpleTile extends ViewModel {
     constructor(entry, options) {
         super(options);
         this._entry = entry;
+        this._emitUpdate = undefined;
     }
     // view model props for all subclasses
     // hmmm, could also do instanceof ... ?
@@ -67,16 +68,20 @@ export class SimpleTile extends ViewModel {
 
     // TilesCollection contract below
     setUpdateEmit(emitUpdate) {
-        this.updateOptions({emitChange: paramName => {
+        this._emitUpdate = emitUpdate;
+    }
+
+    /** overrides the emitChange in ViewModel to also emit the update over the tiles collection */
+    emitChange(changedProps) {
+        if (this._emitUpdate) {
             // it can happen that after some network call
             // we switched away from the room and the response
             // comes in, triggering an emitChange in a tile that
             // has been disposed already (and hence the change
             // callback has been cleared by dispose) We should just ignore this.
-            if (emitUpdate) {
-                emitUpdate(this, paramName);
-            }
-        }});
+            this._emitUpdate(this, changedProps);
+        }
+        super.emitChange(changedProps);
     }
 
     get upperEntry() {


### PR DESCRIPTION
Fixes #720, #729 

Every tile that is created is passed `this._tilesOptions` as its options parameter, meaning that all the tiles share this common object for its `options`. So when `setUpdateEmit()` is called for any one of the tiles and `emitChange` in `options` is replaced, this change also reflects in the `options` of all the other tiles. So all `emitChange` calls result in the last added tile getting updated.

This was introduced via https://github.com/vector-im/hydrogen-web/commit/5445db2a42719d809f65d49f74ecb923dbfdad0d