### PR TITLE
Theme chooser improvements

### DIFF
--- a/scripts/build-plugins/rollup-plugin-build-themes.js
+++ b/scripts/build-plugins/rollup-plugin-build-themes.js
@@ -254,50 +254,9 @@ module.exports = function buildThemes(options) {
                 const derivedVariables = compiledVariables["derived-variables"];
                 const icon = compiledVariables["icon"];
                 const builtAssets = {};
-                let defaultDarkVariant = {}, defaultLightVariant = {};
-                const themeName = manifest.name;
                 for (const chunk of chunkArray) {
                     const [, name, variant] = chunk.fileName.match(/theme-(.+)-(.+)\.css/);
-                    const {name: variantName, default: isDefault, dark} = manifest.values.variants[variant];
-                    const themeId = `${name}-${variant}`;
-                    const themeDisplayName = `${themeName} ${variantName}`;
-                    if (isDefault) {
-                        /**
-                         * This is a default variant!
-                         * We'll add these to the builtAssets (separately) keyed with just the
-                         * theme-name (i.e "Element" instead of "Element Dark").
-                         * We need to be able to distinguish them from other variants!
-                         * 
-                         * This allows us to render radio-buttons with "dark" and
-                         * "light" options.
-                        */ 
-                        const defaultVariant = dark ? defaultDarkVariant : defaultLightVariant;
-                        defaultVariant.variantName = variantName;
-                        defaultVariant.id = themeId
-                        defaultVariant.cssLocation = assetMap.get(chunk.fileName).fileName;
-                        continue;
-                    }
-                    // Non-default variants are keyed in builtAssets with "theme_name variant_name"
-                    // eg: "Element Dark"
-                    builtAssets[themeDisplayName] = {
-                        cssLocation: assetMap.get(chunk.fileName).fileName,
-                        id: themeId
-                    };
-                }
-                if (defaultDarkVariant.id && defaultLightVariant.id) {
-                    /**
-                     * As mentioned above, if there's both a default dark and a default light variant,
-                     * add them to builtAsset separately.
-                     */
-                    builtAssets[themeName] = { dark: defaultDarkVariant, light: defaultLightVariant };
-                }
-                else {
-                    /**
-                     * If only one default variant is found (i.e only dark default or light default but not both),
-                     * treat it like any other variant.
-                     */
-                    const variant = defaultDarkVariant.id ? defaultDarkVariant : defaultLightVariant;
-                    builtAssets[`${themeName} ${variant.variantName}`] = { id: variant.id, cssLocation: variant.cssLocation };
+                    builtAssets[`${name}-${variant}`] = assetMap.get(chunk.fileName).fileName;
                 }
                 manifest.source = {
                     "built-assets": builtAssets,

--- a/scripts/build-plugins/rollup-plugin-build-themes.js
+++ b/scripts/build-plugins/rollup-plugin-build-themes.js
@@ -264,11 +264,11 @@ module.exports = function buildThemes(options) {
                     if (isDefault) {
                         /**
                          * This is a default variant!
-                         * We'll add these to the builtAssets keyed with just the
-                         * theme-name (i.e "Element" instead of "Element Dark")
-                         * so that we can distinguish them from other variants!
+                         * We'll add these to the builtAssets (separately) keyed with just the
+                         * theme-name (i.e "Element" instead of "Element Dark").
+                         * We need to be able to distinguish them from other variants!
                          * 
-                         * This allows us to render a radio-button with "dark" and
+                         * This allows us to render radio-buttons with "dark" and
                          * "light" options.
                         */ 
                         const defaultVariant = dark ? defaultDarkVariant : defaultLightVariant;

--- a/scripts/build-plugins/rollup-plugin-build-themes.js
+++ b/scripts/build-plugins/rollup-plugin-build-themes.js
@@ -246,6 +246,9 @@ module.exports = function buildThemes(options) {
 },
 
         generateBundle(_, bundle) {
+            // assetMap: Mapping from asset-name (eg: element-dark.css) to AssetInfo
+            // chunkMap: Mapping from theme-location (eg: hydrogen-web/src/.../css/themes/element) to a list of ChunkInfo 
+            // types of AssetInfo and ChunkInfo can be found at https://rollupjs.org/guide/en/#generatebundle
             const { assetMap, chunkMap, runtimeThemeChunk } = parseBundle(bundle);
             const manifestLocations = [];
             for (const [location, chunkArray] of chunkMap) {

--- a/scripts/build-plugins/rollup-plugin-build-themes.js
+++ b/scripts/build-plugins/rollup-plugin-build-themes.js
@@ -272,7 +272,7 @@ module.exports = function buildThemes(options) {
                          * "light" options.
                         */ 
                         const defaultVariant = dark ? defaultDarkVariant : defaultLightVariant;
-                        defaultVariant.themeDisplayName = variantName;
+                        defaultVariant.variantName = variantName;
                         defaultVariant.id = themeId
                         defaultVariant.cssLocation = assetMap.get(chunk.fileName).fileName;
                         continue;
@@ -297,7 +297,7 @@ module.exports = function buildThemes(options) {
                      * treat it like any other variant.
                      */
                     const variant = defaultDarkVariant.id ? defaultDarkVariant : defaultLightVariant;
-                    builtAssets[`${themeName} ${variant.themeDisplayName}`] = { id: variant.id, cssLocation: variant.cssLocation };
+                    builtAssets[`${themeName} ${variant.variantName}`] = { id: variant.id, cssLocation: variant.cssLocation };
                 }
                 manifest.source = {
                     "built-assets": builtAssets,

--- a/src/domain/session/settings/SettingsViewModel.js
+++ b/src/domain/session/settings/SettingsViewModel.js
@@ -183,13 +183,7 @@ export class SettingsViewModel extends ViewModel {
     }
 
     changeThemeOption(themeName, themeVariant) {
-        if (themeName && "id" in this.themeMapping[themeName]) {
-            this.platform.themeLoader.setTheme(themeName);
-        }
-        else {
-            this.platform.themeLoader.setTheme(themeName, themeVariant);
-        }
-        // if there's no themeId, then the theme is going to be set via radio-buttons
+        this.platform.themeLoader.setTheme(themeName, themeVariant);
         // emit so that radio-buttons become displayed/hidden
         this.emitChange("themeOption");
     }

--- a/src/domain/session/settings/SettingsViewModel.js
+++ b/src/domain/session/settings/SettingsViewModel.js
@@ -51,7 +51,6 @@ export class SettingsViewModel extends ViewModel {
         this.maxSentImageSizeLimit = 4000;
         this.pushNotifications = new PushNotificationStatus();
         this._activeTheme = undefined;
-        this._activeVariant = undefined;
     }
 
     get _session() {
@@ -80,7 +79,6 @@ export class SettingsViewModel extends ViewModel {
         this.pushNotifications.enabled = await this._session.arePushNotificationsEnabled();
         if (!import.meta.env.DEV) {
             this._activeTheme = await this.platform.themeLoader.getActiveTheme();
-            this._activeVariant = await this.platform.themeLoader.getCurrentVariant();
         }
         this.emitChange("");
     }
@@ -141,14 +139,6 @@ export class SettingsViewModel extends ViewModel {
         return this._activeTheme;
     }
 
-    get activeVariant() {
-        return this._activeVariant;
-    }
-
-    setTheme(name) {
-        this.platform.themeLoader.setTheme(name);
-    }
-
     _formatBytes(n) {
         if (typeof n === "number") {
             return Math.round(n / (1024 * 1024)).toFixed(1) + " MB";
@@ -192,9 +182,12 @@ export class SettingsViewModel extends ViewModel {
         }
     }
 
-    changeThemeOption(themeId) {
-        if (themeId) {
-            this.setTheme(themeId);
+    changeThemeOption(themeName, themeVariant) {
+        if (themeName && "id" in this.themeMapping[themeName]) {
+            this.platform.themeLoader.setTheme(themeName);
+        }
+        else {
+            this.platform.themeLoader.setTheme(themeName, themeVariant);
         }
         // if there's no themeId, then the theme is going to be set via radio-buttons
         // emit so that radio-buttons become displayed/hidden
@@ -204,13 +197,5 @@ export class SettingsViewModel extends ViewModel {
     get preferredColorScheme() {
         return this.platform.themeLoader.preferredColorScheme;
     } 
-
-    persistVariantToStorage(variant) {
-        this.platform.themeLoader.persistVariantToStorage(variant);
-    }
-
-    removeVariantFromStorage() {
-        this.platform.themeLoader.removeVariantFromStorage();
-    }
 }
 

--- a/src/domain/session/settings/SettingsViewModel.js
+++ b/src/domain/session/settings/SettingsViewModel.js
@@ -186,7 +186,7 @@ export class SettingsViewModel extends ViewModel {
         }
     }
 
-    themeOptionChanged(themeId) {
+    changeThemeOption(themeId) {
         if (themeId) {
             this.setTheme(themeId);
         }

--- a/src/domain/session/settings/SettingsViewModel.js
+++ b/src/domain/session/settings/SettingsViewModel.js
@@ -51,6 +51,7 @@ export class SettingsViewModel extends ViewModel {
         this.maxSentImageSizeLimit = 4000;
         this.pushNotifications = new PushNotificationStatus();
         this._activeTheme = undefined;
+        this._activeVariant = undefined;
     }
 
     get _session() {
@@ -79,6 +80,7 @@ export class SettingsViewModel extends ViewModel {
         this.pushNotifications.enabled = await this._session.arePushNotificationsEnabled();
         if (!import.meta.env.DEV) {
             this._activeTheme = await this.platform.themeLoader.getActiveTheme();
+            this._activeVariant = await this.platform.themeLoader.getCurrentVariant();
         }
         this.emitChange("");
     }
@@ -139,6 +141,10 @@ export class SettingsViewModel extends ViewModel {
         return this._activeTheme;
     }
 
+    get activeVariant() {
+        return this._activeVariant;
+    }
+
     setTheme(name) {
         this.platform.themeLoader.setTheme(name);
     }
@@ -195,5 +201,16 @@ export class SettingsViewModel extends ViewModel {
         this.emitChange("themeOption");
     }
 
+    get preferredColorScheme() {
+        return this.platform.themeLoader.preferredColorScheme;
+    } 
+
+    persistVariantToStorage(variant) {
+        this.platform.themeLoader.persistVariantToStorage(variant);
+    }
+
+    removeVariantFromStorage() {
+        this.platform.themeLoader.removeVariantFromStorage();
+    }
 }
 

--- a/src/domain/session/settings/SettingsViewModel.js
+++ b/src/domain/session/settings/SettingsViewModel.js
@@ -131,8 +131,8 @@ export class SettingsViewModel extends ViewModel {
         return this._formatBytes(this._estimate?.usage);
     }
 
-    get themes() {
-        return this.platform.themeLoader.themes;
+    get themeMapping() {
+        return this.platform.themeLoader.themeMapping;
     }
 
     get activeTheme() {
@@ -185,5 +185,15 @@ export class SettingsViewModel extends ViewModel {
             this.emitChange("pushNotifications.serverError");
         }
     }
+
+    themeOptionChanged(themeId) {
+        if (themeId) {
+            this.setTheme(themeId);
+        }
+        // if there's no themeId, then the theme is going to be set via radio-buttons
+        // emit so that radio-buttons become displayed/hidden
+        this.emitChange("themeOption");
+    }
+
 }
 

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -189,7 +189,8 @@ export class Platform {
                 );
                 const manifests = this.config["themeManifests"];
                 await this._themeLoader?.init(manifests);
-                this._themeLoader?.setTheme(await this._themeLoader.getActiveTheme(), log);
+                const { themeName, themeVariant } = await this._themeLoader.getActiveTheme();
+                this._themeLoader?.setTheme(themeName, themeVariant, log);
             });
         } catch (err) {
             this._container.innerText = err.message;

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -188,8 +188,9 @@ export class Platform {
                     this._config.push
                 );
                 const manifests = this.config["themeManifests"];
-                await this._themeLoader?.init(manifests);
+                await this._themeLoader?.init(manifests, log);
                 const { themeName, themeVariant } = await this._themeLoader.getActiveTheme();
+                log.log({ l: "Active theme", name: themeName, variant: themeVariant });
                 this._themeLoader?.setTheme(themeName, themeVariant, log);
             });
         } catch (err) {

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -187,11 +187,13 @@ export class Platform {
                     this._serviceWorkerHandler,
                     this._config.push
                 );
-                const manifests = this.config["themeManifests"];
-                await this._themeLoader?.init(manifests, log);
-                const { themeName, themeVariant } = await this._themeLoader.getActiveTheme();
-                log.log({ l: "Active theme", name: themeName, variant: themeVariant });
-                this._themeLoader?.setTheme(themeName, themeVariant, log);
+                if (this._themeLoader) {
+                    const manifests = this.config["themeManifests"];
+                    await this._themeLoader?.init(manifests, log);
+                    const { themeName, themeVariant } = await this._themeLoader.getActiveTheme();
+                    log.log({ l: "Active theme", name: themeName, variant: themeVariant });
+                    this._themeLoader.setTheme(themeName, themeVariant, log);
+                }
             });
         } catch (err) {
             this._container.innerText = err.message;

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -60,6 +60,14 @@ export class ThemeLoader {
             details which includes the location of the CSS file.
             */
             Object.assign(this._themeMapping, body["source"]["built-assets"]);
+            //Add the default-theme as an additional option to the mapping
+            const defaultThemeId = this.getDefaultTheme();
+            if (defaultThemeId) {
+                const cssLocation = this._findThemeLocationFromId(defaultThemeId);
+                if (cssLocation) {
+                    this._themeMapping["Default"] = { id: "default", cssLocation };
+                }
+            }
         }
     }
 

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -34,6 +34,7 @@ type DefaultVariant = {
         variantName: string;
     };
 }
+
 type ThemeInformation = NormalVariant | DefaultVariant; 
 
 export class ThemeLoader {
@@ -57,7 +58,8 @@ export class ThemeLoader {
             /*
             After build has finished, the source section of each theme manifest
             contains `built-assets` which is a mapping from the theme-name to theme
-            details which includes the location of the CSS file.
+            information which includes the location of the CSS file.
+            (see type ThemeInformation above)
             */
             Object.assign(this._themeMapping, body["source"]["built-assets"]);
             //Add the default-theme as an additional option to the mapping

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -79,18 +79,19 @@ export class ThemeLoader {
     }
 
     async getActiveTheme(): Promise<string> {
-        // check if theme is set via settings
-        let theme = await this._platform.settingsStorage.getString("theme");
+        const theme = await this._platform.settingsStorage.getString("theme") ?? this.getDefaultTheme();
         if (theme) {
             return theme;
         }
-        // return default theme
+        throw new Error("Cannot find active theme!");
+    }
+
+    getDefaultTheme(): string | undefined {
         if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
             return this._platform.config["defaultTheme"].dark;
         } else if (window.matchMedia("(prefers-color-scheme: light)").matches) {
             return this._platform.config["defaultTheme"].light;
         }
-        throw new Error("Cannot find active theme!");
     }
 
     private _findThemeLocationFromId(themeId: string) {

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -26,12 +26,12 @@ type DefaultVariant = {
     dark: {
         id: string;
         cssLocation: string;
-        themeDisplayName: string;
+        variantName: string;
     };
     light: {
         id: string;
         cssLocation: string;
-        themeDisplayName: string;
+        variantName: string;
     };
 }
 type ThemeInformation = NormalVariant | DefaultVariant; 

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -66,24 +66,15 @@ export class ThemeLoader {
                 })
                 .response();
             this._populateThemeMap(body);
-            /*
-            After build has finished, the source section of each theme manifest
-            contains `built-assets` which is a mapping from the theme-name to theme
-            information which includes the location of the CSS file.
-            (see type ThemeInformation above)
-            */
-            //Add the default-theme as an additional option to the mapping
-            const defaultThemeId = this.getDefaultTheme();
-            if (defaultThemeId) {
-                const themeDetails = this._findThemeDetailsFromId(defaultThemeId);
-                if (themeDetails) {
-                    this._themeMapping["Default"] = { id: "default", cssLocation: themeDetails.cssLocation };
-                }
-            }
         }
     }
 
     private _populateThemeMap(manifest) {
+        /*
+        After build has finished, the source section of each theme manifest
+        contains `built-assets` which is a mapping from the theme-id to
+        cssLocation of theme
+        */
         const builtAssets: Record<string, string> = manifest.source?.["built-assets"];
         const themeName = manifest.name;
         let defaultDarkVariant: any = {}, defaultLightVariant: any = {};
@@ -129,6 +120,14 @@ export class ThemeLoader {
              */
             const variant = defaultDarkVariant.id ? defaultDarkVariant : defaultLightVariant;
             this._themeMapping[`${themeName} ${variant.variantName}`] = { id: variant.id, cssLocation: variant.cssLocation };
+        }
+        //Add the default-theme as an additional option to the mapping
+        const defaultThemeId = this.getDefaultTheme();
+        if (defaultThemeId) {
+            const themeDetails = this._findThemeDetailsFromId(defaultThemeId);
+            if (themeDetails) {
+                this._themeMapping["Default"] = { id: "default", cssLocation: themeDetails.cssLocation };
+            }
         }
     }
 

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -87,7 +87,7 @@ export class ThemeLoader {
     }
 
     async getActiveTheme(): Promise<string> {
-        const theme = await this._platform.settingsStorage.getString("theme") ?? this.getDefaultTheme();
+        const theme = await this._platform.settingsStorage.getString("theme") ?? "default";
         if (theme) {
             return theme;
         }

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -73,14 +73,14 @@ export class ThemeLoader {
         }
     }
 
-    setTheme(themeName: string, log?: ILogItem) {
-        this._platform.logger.wrapOrRun(log, {l: "change theme", id: themeName}, () => {
-            const themeLocation = this._findThemeLocationFromId(themeName);
+    setTheme(themeId: string, log?: ILogItem) {
+        this._platform.logger.wrapOrRun(log, {l: "change theme", id: themeId}, () => {
+            const themeLocation = this._findThemeLocationFromId(themeId);
             if (!themeLocation) {
-                throw new Error( `Cannot find theme location for theme "${themeName}"!`);
+                throw new Error( `Cannot find theme location for theme "${themeId}"!`);
             }
             this._platform.replaceStylesheet(themeLocation);
-            this._platform.settingsStorage.setString("theme", themeName);
+            this._platform.settingsStorage.setString("theme", themeId);
          });
     }
 

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -157,8 +157,14 @@ export class ThemeLoader {
     }
 
     async getActiveTheme(): Promise<{themeName: string, themeVariant?: string}> {
-        const themeName = await this._platform.settingsStorage.getString("theme-name") ?? "Default";
-        const themeVariant = await this._platform.settingsStorage.getString("theme-variant");
+        let themeName = await this._platform.settingsStorage.getString("theme-name");
+        let themeVariant = await this._platform.settingsStorage.getString("theme-variant");
+        if (!themeName || !this._themeMapping[themeName]) {
+            themeName = "Default" in this._themeMapping ? "Default" : Object.keys(this._themeMapping)[0];
+            if (!this._themeMapping[themeName][themeVariant]) {
+                themeVariant = "default" in this._themeMapping[themeName] ? "default" : undefined;
+            }
+        }
         return { themeName, themeVariant };
     }
 

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -165,9 +165,9 @@ export class ThemeLoader {
     getDefaultTheme(): string | undefined {
         switch (this.preferredColorScheme) {
             case ColorSchemePreference.Dark:
-                return this._platform.config["defaultTheme"].dark;
+                return this._platform.config["defaultTheme"]?.dark;
             case ColorSchemePreference.Light:
-                return this._platform.config["defaultTheme"].light;
+                return this._platform.config["defaultTheme"]?.light;
         }
     }
 

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -58,16 +58,10 @@ export class ThemeLoader {
     async init(manifestLocations: string[], log?: ILogItem): Promise<void> {
         await this._platform.logger.wrapOrRun(log, "ThemeLoader.init", async (log) => {
             this._themeMapping = {};
-            for (const manifestLocation of manifestLocations) {
-                const { body } = await this._platform
-                    .request(manifestLocation, {
-                        method: "GET",
-                        format: "json",
-                        cache: true,
-                    })
-                    .response();
-                this._populateThemeMap(body, log);
-            }
+            const results = await Promise.all(
+                manifestLocations.map( location => this._platform.request(location, { method: "GET", format: "json", cache: true, }).response())
+            );
+            results.forEach(({ body }) => this._populateThemeMap(body, log));
         });
     }
 

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -131,7 +131,7 @@ export class ThemeLoader {
         }
     }
 
-    setTheme(themeName: string, themeVariant: "light" | "dark" | "default", log?: ILogItem) {
+    setTheme(themeName: string, themeVariant?: "light" | "dark" | "default", log?: ILogItem) {
         this._platform.logger.wrapOrRun(log, { l: "change theme", name: themeName, variant: themeVariant }, () => {
             let cssLocation: string;
             let themeDetails = this._themeMapping[themeName];
@@ -139,7 +139,10 @@ export class ThemeLoader {
                 cssLocation = themeDetails.cssLocation;
             }
             else {
-                cssLocation = themeDetails[themeVariant ?? "default"].cssLocation;
+                if (!themeVariant) {
+                    throw new Error("themeVariant is undefined!");
+                }
+                cssLocation = themeDetails[themeVariant].cssLocation;
             }
             this._platform.replaceStylesheet(cssLocation);
             this._platform.settingsStorage.setString("theme-name", themeName);

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -58,7 +58,7 @@ export class ThemeLoader {
         return Object.keys(this._themeMapping);
     }
 
-    async getActiveTheme(): Promise<string|undefined> {
+    async getActiveTheme(): Promise<string> {
         // check if theme is set via settings
         let theme = await this._platform.settingsStorage.getString("theme");
         if (theme) {
@@ -70,6 +70,6 @@ export class ThemeLoader {
         } else if (window.matchMedia("(prefers-color-scheme: light)").matches) {
             return this._platform.config["defaultTheme"].light;
         }
-        return undefined;
+        throw new Error("Cannot find active theme!");
     }
 }

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -94,7 +94,7 @@ export class ThemeLoader {
         }
     }
 
-    private _findThemeLocationFromId(themeId: string) {
+    private _findThemeLocationFromId(themeId: string): string | undefined {
         for (const themeData of Object.values(this._themeMapping)) {
             if ("id" in themeData && themeData.id === themeId) {
                 return themeData.cssLocation;

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -162,6 +162,7 @@ export class ThemeLoader {
         });
     }
 
+    /** Maps theme display name to theme information */
     get themeMapping(): Record<string, ThemeInformation> {
         return this._themeMapping;
     }

--- a/src/platform/web/ui/css/themes/element/manifest.json
+++ b/src/platform/web/ui/css/themes/element/manifest.json
@@ -1,7 +1,6 @@
 {
 	"version": 1,
     "name": "Element",
-	"id": "element",
 	"values": {
 		"font-faces": [
 			{

--- a/src/platform/web/ui/css/themes/element/manifest.json
+++ b/src/platform/web/ui/css/themes/element/manifest.json
@@ -1,6 +1,7 @@
 {
 	"version": 1,
-	"name": "element",
+    "name": "Element",
+	"id": "element",
 	"values": {
 		"font-faces": [
 			{
@@ -9,37 +10,51 @@
 			}
 		],
 		"variants": {
-			"light": {
-				"base": true,
-				"default": true,
-				"name": "Light",
-				"variables": {
-					"background-color-primary": "#fff",
+            "light": {
+                "base": true,
+                "default": true,
+                "name": "Light",
+                "variables": {
+                    "background-color-primary": "#fff",
                     "background-color-secondary": "#f6f6f6",
-					"text-color": "#2E2F32",
+                    "text-color": "#2E2F32",
                     "accent-color": "#03b381",
                     "error-color": "#FF4B55",
                     "fixed-white": "#fff",
                     "room-badge": "#61708b",
                     "link-color": "#238cf5"
-				}
-			},
-			"dark": {
-				"dark": true,
-				"default": true,
-				"name": "Dark",
-				"variables": {
-					"background-color-primary": "#21262b",
+                }
+            },
+            "dark": {
+                "dark": true,
+                "default": true,
+                "name": "Dark",
+                "variables": {
+                    "background-color-primary": "#21262b",
                     "background-color-secondary": "#2D3239",
-					"text-color": "#fff",
+                    "text-color": "#fff",
                     "accent-color": "#03B381",
                     "error-color": "#FF4B55",
                     "fixed-white": "#fff",
                     "room-badge": "#61708b",
                     "link-color": "#238cf5"
-				}
-			}
-		}
+                }
+            },
+            "violet": {
+                "dark": true,
+                "name": "Violet",
+                "variables": {
+                    "background-color-primary": "#21262b",
+                    "background-color-secondary": "#2D3239",
+                    "text-color": "#fff",
+                    "accent-color": "#03B381",
+                    "error-color": "#FF4B55",
+                    "fixed-white": "#fff",
+                    "room-badge": "#61708b",
+                    "link-color": "#238cf5"
+                }
+            }
+        }
 	}
 }
 

--- a/src/platform/web/ui/css/themes/element/manifest.json
+++ b/src/platform/web/ui/css/themes/element/manifest.json
@@ -2,12 +2,6 @@
 	"version": 1,
     "name": "Element",
 	"values": {
-		"font-faces": [
-			{
-				"font-family": "Inter",
-				"src": [{"asset": "/fonts/Inter.ttf", "format": "ttf"}]
-			}
-		],
 		"variants": {
             "light": {
                 "base": true,

--- a/src/platform/web/ui/css/themes/element/manifest.json
+++ b/src/platform/web/ui/css/themes/element/manifest.json
@@ -38,20 +38,6 @@
                     "room-badge": "#61708b",
                     "link-color": "#238cf5"
                 }
-            },
-            "violet": {
-                "dark": true,
-                "name": "Violet",
-                "variables": {
-                    "background-color-primary": "#21262b",
-                    "background-color-secondary": "#2D3239",
-                    "text-color": "#fff",
-                    "accent-color": "#03B381",
-                    "error-color": "#FF4B55",
-                    "fixed-white": "#fff",
-                    "room-badge": "#61708b",
-                    "link-color": "#238cf5"
-                }
             }
         }
 	}

--- a/src/platform/web/ui/session/settings/SettingsView.js
+++ b/src/platform/web/ui/session/settings/SettingsView.js
@@ -142,9 +142,37 @@ export class SettingsView extends TemplateView {
     _themeOptions(t, vm) {
         const activeTheme = vm.activeTheme;
         const optionTags = [];
-        for (const name of vm.themes) {
-            optionTags.push(t.option({value: name, selected: name === activeTheme}, name));
+        let isDarkSelected = null, isLightSelected = null; 
+        for (const [name, details] of Object.entries(vm.themeMapping)) {
+            let isSelected = null;
+            if (details.id === activeTheme) {
+                isSelected = true;
+            }
+            else if (details.dark?.id === activeTheme) {
+                isSelected = true;
+                isDarkSelected = true;
+            }
+            else if (details.light?.id === activeTheme) {
+                isSelected = true;
+                isLightSelected = true;
+            }
+            optionTags.push( t.option({ value: details.id ?? "", selected: isSelected} , name));
         }
-        return t.select({onChange: (e) => vm.setTheme(e.target.value)}, optionTags);
+        const select = t.select({ onChange: (e) => vm.themeOptionChanged(e.target.value) }, optionTags);
+        const radioButtons = t.form({
+            className: { hidden: () => select.options[select.selectedIndex].value !== "" },
+            onChange: (e) => {
+                const selectedThemeName = select.options[select.selectedIndex].text;
+                const themeId = vm.themeMapping[selectedThemeName][e.target.value].id;
+                vm.themeOptionChanged(themeId);
+            }
+        },
+        [
+            t.input({ type: "radio", name: "radio-chooser", value: "dark", id: "dark", checked: isDarkSelected }),
+            t.label({for: "dark"}, "dark"),
+            t.input({ type: "radio", name: "radio-chooser", value: "light", id: "light", checked: isLightSelected }),
+            t.label({for: "light"}, "light"),
+        ]);
+        return t.div({ className: "theme-chooser" }, [select, radioButtons]);
     }
 }

--- a/src/platform/web/ui/session/settings/SettingsView.js
+++ b/src/platform/web/ui/session/settings/SettingsView.js
@@ -16,7 +16,6 @@ limitations under the License.
 
 import {TemplateView} from "../../general/TemplateView";
 import {KeyBackupSettingsView} from "./KeyBackupSettingsView.js"
-import {ColorSchemePreference} from "../../../ThemeLoader";
 
 export class SettingsView extends TemplateView {
     render(t, vm) {

--- a/src/platform/web/ui/session/settings/SettingsView.js
+++ b/src/platform/web/ui/session/settings/SettingsView.js
@@ -147,7 +147,9 @@ export class SettingsView extends TemplateView {
         const isLightSelected = vm.activeVariant === "light";
         // 1. render the dropdown containing the themes
         for (const [name, details] of Object.entries(vm.themeMapping)) {
-            const isSelected = (details.id ?? details.dark?.id ?? details.light?.id) === activeTheme;
+            const isSelected = details.id === activeTheme || 
+                            details.dark?.id === activeTheme ||
+                            details.light?.id === activeTheme;
             optionTags.push( t.option({ value: details.id ?? "", selected: isSelected} , name));
         }
         const select = t.select({
@@ -161,7 +163,7 @@ export class SettingsView extends TemplateView {
                     vm.removeVariantFromStorage();
                 }
                 else {
-                    const colorScheme = isDarkSelected ? "dark" : isLightSelected ? "light" : "default";
+                    const colorScheme = darkRadioButton.checked ? "dark" : lightRadioButton.checked ? "light" : "default";
                     // execute the radio-button callback so that the theme actually changes!
                     // otherwise the theme would only change when another radio-button is selected.
                     radioButtonCallback(colorScheme);
@@ -179,16 +181,19 @@ export class SettingsView extends TemplateView {
             const themeId = vm.themeMapping[selectedThemeName][colorScheme].id;
             vm.changeThemeOption(themeId);
         };
+        const darkRadioButton = t.input({ type: "radio", name: "radio-chooser", value: "dark", id: "dark", checked: isDarkSelected });
+        const defaultRadioButton = t.input({ type: "radio", name: "radio-chooser", value: "default", id: "default", checked: !(isDarkSelected || isLightSelected) });
+        const lightRadioButton = t.input({ type: "radio", name: "radio-chooser", value: "light", id: "light", checked: isLightSelected });
         const radioButtons = t.form({
             className: { hidden: () => select.options[select.selectedIndex].value !== "" },
             onChange: (e) => radioButtonCallback(e.target.value)
         },
         [
-            t.input({ type: "radio", name: "radio-chooser", value: "default", id: "default", checked: !(isDarkSelected || isLightSelected)}),
+            defaultRadioButton,
             t.label({for: "default"}, "default"),
-            t.input({ type: "radio", name: "radio-chooser", value: "dark", id: "dark", checked: isDarkSelected }),
+            darkRadioButton,
             t.label({for: "dark"}, "dark"),
-            t.input({ type: "radio", name: "radio-chooser", value: "light", id: "light", checked: isLightSelected }),
+            lightRadioButton,
             t.label({for: "light"}, "light"),
         ]);
         return t.div({ className: "theme-chooser" }, [select, radioButtons]);

--- a/src/platform/web/ui/session/settings/SettingsView.js
+++ b/src/platform/web/ui/session/settings/SettingsView.js
@@ -180,7 +180,7 @@ export class SettingsView extends TemplateView {
         },
         [
             defaultRadioButton,
-            t.label({for: "default"}, "Match System Theme"),
+            t.label({for: "default"}, "Match system theme"),
             darkRadioButton,
             t.label({for: "dark"}, "dark"),
             lightRadioButton,

--- a/src/platform/web/ui/session/settings/SettingsView.js
+++ b/src/platform/web/ui/session/settings/SettingsView.js
@@ -158,13 +158,13 @@ export class SettingsView extends TemplateView {
             }
             optionTags.push( t.option({ value: details.id ?? "", selected: isSelected} , name));
         }
-        const select = t.select({ onChange: (e) => vm.themeOptionChanged(e.target.value) }, optionTags);
+        const select = t.select({ onChange: (e) => vm.changeThemeOption(e.target.value) }, optionTags);
         const radioButtons = t.form({
             className: { hidden: () => select.options[select.selectedIndex].value !== "" },
             onChange: (e) => {
                 const selectedThemeName = select.options[select.selectedIndex].text;
                 const themeId = vm.themeMapping[selectedThemeName][e.target.value].id;
-                vm.themeOptionChanged(themeId);
+                vm.changeThemeOption(themeId);
             }
         },
         [

--- a/src/platform/web/ui/session/settings/SettingsView.js
+++ b/src/platform/web/ui/session/settings/SettingsView.js
@@ -158,12 +158,18 @@ export class SettingsView extends TemplateView {
             }
             optionTags.push( t.option({ value: details.id ?? "", selected: isSelected} , name));
         }
-        const select = t.select({ onChange: (e) => vm.changeThemeOption(e.target.value) }, optionTags);
+        const select = t.select({
+            onChange: (e) => {
+                const themeId = e.target.value;
+                vm.changeThemeOption(themeId)
+            }
+        }, optionTags);
         const radioButtons = t.form({
             className: { hidden: () => select.options[select.selectedIndex].value !== "" },
             onChange: (e) => {
                 const selectedThemeName = select.options[select.selectedIndex].text;
-                const themeId = vm.themeMapping[selectedThemeName][e.target.value].id;
+                const colorScheme = e.target.value;
+                const themeId = vm.themeMapping[selectedThemeName][colorScheme].id;
                 vm.changeThemeOption(themeId);
             }
         },


### PR DESCRIPTION
- [x] Fix typescript types
- [x] Theme list should show dark and light default variant for each theme as radio-buttons. Other variants should be separately enumerated in the dropdown list.
- [x] Theme list should show default OS choice as option