### PR TITLE
Import SDK assets from the `assets/` directory

### DIFF
--- a/doc/SDK.md
+++ b/doc/SDK.md
@@ -48,8 +48,8 @@ const assetPaths = {
         wasmBundle: olmJsPath
     }
 };
-import "hydrogen-view-sdk/theme-element-light.css";
-// OR import "hydrogen-view-sdk/theme-element-dark.css";
+import "hydrogen-view-sdk/assets/theme-element-light.css";
+// OR import "hydrogen-view-sdk/assets/theme-element-dark.css";
 
 async function main() {
     const app = document.querySelector<HTMLDivElement>('#app')!

--- a/scripts/sdk/base-manifest.json
+++ b/scripts/sdk/base-manifest.json
@@ -10,8 +10,6 @@
         },
         "./paths/vite": "./paths/vite.js",
         "./style.css": "./asset-build/assets/theme-element-light.css",
-        "./theme-element-light.css": "./asset-build/assets/theme-element-light.css",
-        "./theme-element-dark.css": "./asset-build/assets/theme-element-dark.css",
         "./main.js": "./asset-build/assets/main.js",
         "./download-sandbox.html": "./asset-build/assets/download-sandbox.html",
         "./assets/*": "./asset-build/assets/*"

--- a/scripts/sdk/base-manifest.json
+++ b/scripts/sdk/base-manifest.json
@@ -10,6 +10,8 @@
         },
         "./paths/vite": "./paths/vite.js",
         "./style.css": "./asset-build/assets/theme-element-light.css",
+        "./theme-element-light.css": "./asset-build/assets/theme-element-light.css",
+        "./theme-element-dark.css": "./asset-build/assets/theme-element-dark.css",
         "./main.js": "./asset-build/assets/main.js",
         "./download-sandbox.html": "./asset-build/assets/download-sandbox.html",
         "./assets/*": "./asset-build/assets/*"

--- a/scripts/sdk/test/esm-entry.ts
+++ b/scripts/sdk/test/esm-entry.ts
@@ -13,7 +13,7 @@ const assetPaths = {
       wasmBundle: olmJsPath
   }
 };
-import "hydrogen-view-sdk/theme-element-light.css";
+import "hydrogen-view-sdk/assets/theme-element-light.css";
 
 console.log('hydrogenViewSdk', hydrogenViewSdk);
 console.log('assetPaths', assetPaths);

--- a/scripts/sdk/test/test-sdk-in-commonjs-env.js
+++ b/scripts/sdk/test/test-sdk-in-commonjs-env.js
@@ -6,7 +6,7 @@ const hydrogenViewSdk = require('hydrogen-view-sdk');
 // Worker
 require.resolve('hydrogen-view-sdk/main.js');
 // Styles
-require.resolve('hydrogen-view-sdk/theme-element-light.css');
+require.resolve('hydrogen-view-sdk/assets/theme-element-light.css');
 // Can access files in the assets/* directory
 require.resolve('hydrogen-view-sdk/assets/main.js');
 

--- a/vite.sdk-assets-config.js
+++ b/vite.sdk-assets-config.js
@@ -3,8 +3,8 @@ const mergeOptions = require('merge-options');
 const themeBuilder = require("./scripts/build-plugins/rollup-plugin-build-themes");
 const {commonOptions, compiledVariables} = require("./vite.common-config.js");
 
-// These paths will be saved without their hash so they havea  consisent path to
-// reference
+// These paths will be saved without their hash so they have a consisent path to
+// reference in imports.
 const pathsToExport = [
     "main.js",
     "download-sandbox.html",

--- a/vite.sdk-assets-config.js
+++ b/vite.sdk-assets-config.js
@@ -3,8 +3,9 @@ const mergeOptions = require('merge-options');
 const themeBuilder = require("./scripts/build-plugins/rollup-plugin-build-themes");
 const {commonOptions, compiledVariables} = require("./vite.common-config.js");
 
-// These paths will be saved without their hash so they have a consisent path to
-// reference in imports.
+// These paths will be saved without their hash so they have a consisent path
+// that we can reference in our `package.json` `exports`. And so people can import
+// them with a consistent path.
 const pathsToExport = [
     "main.js",
     "download-sandbox.html",
@@ -21,7 +22,8 @@ export default mergeOptions(commonOptions, {
             output: {
               assetFileNames: (chunkInfo) => {
                   // Get rid of the hash so we can consistently reference these
-                  // files in our `package.json` `exports`
+                  // files in our `package.json` `exports`. And so people can
+                  // import them with a consistent path.
                   if(pathsToExport.includes(path.basename(chunkInfo.name))) {
                     return "assets/[name].[ext]";
                   }


### PR DESCRIPTION
Import SDK assets from the `assets/` directory

> Will be easier towards the future when adding more assets. Probably best to keep style.css for now for backwards compat though.
>
> *-- @bwindels, https://github.com/vector-im/hydrogen-web/pull/693#discussion_r853844282*

---

```sh
$ yarn test:sdk
...
SDK works in Vite build ✅
SDK works in CommonJS ✅
```