### PR TITLE
Refactor theme builder plugin

### DIFF
--- a/scripts/build-plugins/rollup-plugin-build-themes.js
+++ b/scripts/build-plugins/rollup-plugin-build-themes.js
@@ -257,8 +257,10 @@ module.exports = function buildThemes(options) {
                 const derivedVariables = compiledVariables["derived-variables"];
                 const icon = compiledVariables["icon"];
                 const builtAssets = {};
+                let themeKey;
                 for (const chunk of chunkArray) {
                     const [, name, variant] = chunk.fileName.match(/theme-(.+)-(.+)\.css/);
+                    themeKey = name;
                     builtAssets[`${name}-${variant}`] = assetMap.get(chunk.fileName).fileName;
                 }
                 manifest.source = {
@@ -267,7 +269,7 @@ module.exports = function buildThemes(options) {
                     "derived-variables": derivedVariables,
                     "icon": icon
                 };
-                const name = `theme-${manifest.name}.json`;
+                const name = `theme-${themeKey}.json`;
                 manifestLocations.push(`assets/${name}`);
                 this.emitFile({
                     type: "asset",

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -338,7 +338,7 @@ export class Platform {
         document.querySelectorAll(".theme").forEach(e => e.remove());
         // add new theme
         const styleTag = document.createElement("link");
-        styleTag.href = `./${newPath}`;
+        styleTag.href = newPath;
         styleTag.rel = "stylesheet";
         styleTag.type = "text/css";
         styleTag.className = "theme";

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -76,11 +76,16 @@ export class ThemeLoader {
             const themeName = manifest.name;
             let defaultDarkVariant: any = {}, defaultLightVariant: any = {};
             for (let [themeId, cssLocation] of Object.entries(builtAssets)) {
-                /**
-                 * This cssLocation is relative to the location of the manifest file.
-                 * So we first need to resolve it relative to the root of this hydrogen instance.
-                 */
-                cssLocation = new URL(cssLocation, new URL(manifestLocation, window.location.origin)).href;
+                try {
+                    /**
+                     * This cssLocation is relative to the location of the manifest file.
+                     * So we first need to resolve it relative to the root of this hydrogen instance.
+                     */
+                    cssLocation = new URL(cssLocation, new URL(manifestLocation, window.location.origin)).href;
+                }
+                catch {
+                    continue;
+                }
                 const variant = themeId.match(/.+-(.+)/)?.[1];
                 const { name: variantName, default: isDefault, dark } = manifest.values.variants[variant!];
                 const themeDisplayName = `${themeName} ${variantName}`;

--- a/src/platform/web/ThemeLoader.ts
+++ b/src/platform/web/ThemeLoader.ts
@@ -61,11 +61,11 @@ export class ThemeLoader {
             const results = await Promise.all(
                 manifestLocations.map( location => this._platform.request(location, { method: "GET", format: "json", cache: true, }).response())
             );
-            results.forEach(({ body }) => this._populateThemeMap(body, log));
+            results.forEach(({ body }, i) => this._populateThemeMap(body, manifestLocations[i], log));
         });
     }
 
-    private _populateThemeMap(manifest, log: ILogItem) {
+    private _populateThemeMap(manifest, manifestLocation: string, log: ILogItem) {
         log.wrap("populateThemeMap", (l) => {
             /*
             After build has finished, the source section of each theme manifest
@@ -75,7 +75,12 @@ export class ThemeLoader {
             const builtAssets: Record<string, string> = manifest.source?.["built-assets"];
             const themeName = manifest.name;
             let defaultDarkVariant: any = {}, defaultLightVariant: any = {};
-            for (const [themeId, cssLocation] of Object.entries(builtAssets)) {
+            for (let [themeId, cssLocation] of Object.entries(builtAssets)) {
+                /**
+                 * This cssLocation is relative to the location of the manifest file.
+                 * So we first need to resolve it relative to the root of this hydrogen instance.
+                 */
+                cssLocation = new URL(cssLocation, new URL(manifestLocation, window.location.origin)).href;
                 const variant = themeId.match(/.+-(.+)/)?.[1];
                 const { name: variantName, default: isDefault, dark } = manifest.values.variants[variant!];
                 const themeDisplayName = `${themeName} ${variantName}`;

--- a/src/platform/web/ui/css/themes/element/manifest.json
+++ b/src/platform/web/ui/css/themes/element/manifest.json
@@ -1,6 +1,7 @@
 {
 	"version": 1,
     "name": "Element",
+    "id": "element",
 	"values": {
 		"variants": {
             "light": {

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,9 +33,7 @@ export default defineConfig(({mode}) => {
         plugins: [
             themeBuilder({
                 themeConfig: {
-                    themes: {
-                        element: "./src/platform/web/ui/css/themes/element",
-                    },
+                    themes: ["./src/platform/web/ui/css/themes/element"],
                     default: "element",
                 },
                 compiledVariables,


### PR DESCRIPTION
- [x] Do not use theme name in manifest file name; instead use the theme-key (`theme-element.json` vs `theme-Element.json`)
- [x] Runtime theme chunks should also be aggregated into a map (because there will be more than one runtime asset when we have multiple theme collections)
- [x] Locations in `built-asset`section should be relative to manifest file ([see here](https://github.com/vector-im/hydrogen-web/pull/742#discussion_r892253075))
- [x] Split `parseBundle` function into smaller functions
- [x] Theme Collection id ("element") should come from within the manifest and not from the key in `vite.config.js` i.e add an `id` field to manifest.