### PR TITLE
Require node 15+

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "directories": {
     "doc": "doc"
   },
+  "enginesStrict": {
+    "node": ">=15"
+  },
   "scripts": {
     "lint": "eslint --cache src/",
     "lint-ts": "eslint src/ -c .ts-eslintrc.js --ext .ts",


### PR DESCRIPTION
We use replaceAll in scripts/postcss/svg-colorizer.js which is a ES2021 feature. https://node.green/#ES2021-features--String-prototype-replaceAll.

I ran into this when trying to build on Node 14