### PR TITLE
Add date headers in timeline

### DIFF
--- a/src/domain/session/room/timeline/TilesCollection.js
+++ b/src/domain/session/room/timeline/TilesCollection.js
@@ -130,15 +130,11 @@ export class TilesCollection extends BaseObservableList {
 
         const newTile = this._createTile(entry);
         if (newTile) {
-            if (prevTile) {
-                prevTile.updateNextSibling(newTile);
-                // this emits an update while the add hasn't been emitted yet
-                newTile.updatePreviousSibling(prevTile);
-            }
-            if (nextTile) {
-                newTile.updateNextSibling(nextTile);
-                nextTile.updatePreviousSibling(newTile);
-            }
+            prevTile?.updateNextSibling(newTile);
+            // this emits an update while the add hasn't been emitted yet
+            newTile.updatePreviousSibling(prevTile);
+            newTile.updateNextSibling(nextTile);
+            nextTile?.updatePreviousSibling(newTile);
             this._tiles.splice(tileIdx, 0, newTile);
             this.emitAdd(tileIdx, newTile);
             // add event is emitted, now the tile

--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -133,8 +133,7 @@ export class BaseMessageTile extends SimpleTile {
             const action = this._replyTile?.updateEntry(replyEntry, param);
             if (action?.shouldReplace || !this._replyTile) {
                 this.disposeTracked(this._replyTile);
-                const tileClassForEntry = this._options.tileClassForEntry;
-                const ReplyTile = tileClassForEntry(replyEntry);
+                const ReplyTile = this._options.tileClassForEntry(replyEntry);
                 if (ReplyTile) {
                     this._replyTile = new ReplyTile(replyEntry, this._options);
                 }

--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -21,7 +21,6 @@ import {getIdentifierColorNumber, avatarInitials, getAvatarHttpUrl} from "../../
 export class BaseMessageTile extends SimpleTile {
     constructor(entry, options) {
         super(entry, options);
-        this._date = this._entry.timestamp ? new Date(this._entry.timestamp) : null;
         this._isContinuation = false;
         this._reactions = null;
         this._replyTile = null;
@@ -76,10 +75,6 @@ export class BaseMessageTile extends SimpleTile {
 
     get avatarTitle() {
         return this.sender;
-    }
-
-    get date() {
-        return this._date && this._date.toLocaleDateString({}, {month: "numeric", day: "numeric"});
     }
 
     get time() {

--- a/src/domain/session/room/timeline/tiles/SimpleTile.js
+++ b/src/domain/session/room/timeline/tiles/SimpleTile.js
@@ -23,6 +23,7 @@ export class SimpleTile extends ViewModel {
         super(options);
         this._entry = entry;
         this._date = this._entry.timestamp ? new Date(this._entry.timestamp) : null;
+        this._hasDateSeparator = false;
         this._emitUpdate = undefined;
     }
     // view model props for all subclasses
@@ -39,7 +40,25 @@ export class SimpleTile extends ViewModel {
     }
 
     get hasDateSeparator() {
-        return false;
+        return this._hasDateSeparator;
+    }
+
+    _updateDateSeparator(prev) {
+        let hasDateSeparator;
+        if (prev instanceof SimpleTile) {
+            if (prev && prev._date) {
+                hasDateSeparator = prev._date.getFullYear() !== this._date.getFullYear() ||
+                    prev._date.getMonth() !== this._date.getMonth() ||
+                    prev._date.getDate() !== this._date.getDate();
+            } else {
+                hasDateSeparator = !!this._date;
+            }
+        } else {
+            hasDateSeparator = true;
+        }
+        const changed = hasDateSeparator !== this._hasDateSeparator;
+        this._hasDateSeparator = hasDateSeparator;
+        return changed;
     }
 
     get id() {
@@ -127,9 +146,12 @@ export class SimpleTile extends ViewModel {
     tryIncludeEntry() {
         return false;
     }
-    // let item know it has a new sibling
-    updatePreviousSibling(/*prev*/) {
 
+    // let item know it has a new sibling
+    updatePreviousSibling(prev) {
+        if (this._updateDateSeparator(prev)) {
+            this.emitChange();
+        }
     }
 
     // let item know it has a new sibling

--- a/src/domain/session/room/timeline/tiles/SimpleTile.js
+++ b/src/domain/session/room/timeline/tiles/SimpleTile.js
@@ -22,6 +22,7 @@ export class SimpleTile extends ViewModel {
     constructor(entry, options) {
         super(options);
         this._entry = entry;
+        this._date = this._entry.timestamp ? new Date(this._entry.timestamp) : null;
         this._emitUpdate = undefined;
     }
     // view model props for all subclasses
@@ -43,6 +44,10 @@ export class SimpleTile extends ViewModel {
 
     get id() {
         return this._entry.asEventKey();
+    }
+
+    get date() {
+        return this._date && this._date.toLocaleDateString({}, {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'});
     }
 
     get eventId() {

--- a/src/domain/session/room/timeline/tiles/SimpleTile.js
+++ b/src/domain/session/room/timeline/tiles/SimpleTile.js
@@ -46,7 +46,7 @@ export class SimpleTile extends ViewModel {
     _updateDateSeparator(prev) {
         let hasDateSeparator;
         if (prev instanceof SimpleTile) {
-            if (prev && prev._date) {
+            if (prev && prev._date && this._date) {
                 hasDateSeparator = prev._date.getFullYear() !== this._date.getFullYear() ||
                     prev._date.getMonth() !== this._date.getMonth() ||
                     prev._date.getDate() !== this._date.getDate();

--- a/src/platform/web/ui/css/themes/element/timeline.css
+++ b/src/platform/web/ui/css/themes/element/timeline.css
@@ -103,7 +103,7 @@ limitations under the License.
     /* reset body margin */
     margin: 0;
     /* first try break-all, then break-word, which isn't supported everywhere */
-    word-break: break-all;  
+    word-break: break-all;
     word-break: break-word;
 }
 
@@ -422,3 +422,17 @@ only loads when the top comes into view*/
 .GapView.isAtTop {
     padding: 52px 20px 12px 20px;
 }
+
+.DateSeparator {
+    display: flex;
+    justify-content: center;
+    margin: 8px 0;
+}
+
+.DateSeparator > time {
+    background-color: var(--background-color-primary--darker-10);
+    border-radius: 16px;
+    padding: 4px 16px;
+}
+
+

--- a/src/platform/web/ui/session/room/MessageComposer.js
+++ b/src/platform/web/ui/session/room/MessageComposer.js
@@ -55,7 +55,7 @@ export class MessageComposer extends TemplateView {
                         className: "cancel",
                         onClick: () => this._clearReplyingTo()
                     }, "Close"),
-                t.view(new TileView(rvm, this._viewClassForTile, { interactive: false }, "div"))
+                t.view(new TileView(rvm, this._viewClassForTile, { interactive: false }))
             ]);
         });
         const input = t.div({className: "MessageComposer_input"}, [

--- a/src/platform/web/ui/session/room/TimelineView.ts
+++ b/src/platform/web/ui/session/room/TimelineView.ts
@@ -192,6 +192,7 @@ class TilesListView extends ListView<SimpleTile, TileView> {
         super({
             list: tiles,
             onItemClick: (tileView, evt) => tileView.onClick(evt),
+            tagName: "div"
         }, tile => {
             const TileView = viewClassForTile(tile);
             return new TileView(tile, viewClassForTile);

--- a/src/platform/web/ui/session/room/timeline/AnnouncementView.js
+++ b/src/platform/web/ui/session/room/timeline/AnnouncementView.js
@@ -14,21 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {TemplateView} from "../../../general/TemplateView";
+import {BaseTileView} from "./BaseTileView";
 
-export class AnnouncementView extends TemplateView {
-    // ignore other arguments
-    constructor(vm) {
-        super(vm);
-    }
-
-    render(t, vm) {
-        return t.li({
+export class AnnouncementView extends BaseTileView {
+    renderTile(t, vm) {
+        return t.div({
             className: "AnnouncementView",
             'data-event-id': vm.eventId
         }, t.div(vm => vm.announcement));
     }
-    
-    /* This is called by the parent ListView, which just has 1 listener for the whole list */
-    onClick() {}
 }

--- a/src/platform/web/ui/session/room/timeline/BaseTileView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseTileView.js
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 Bruno Windels <bruno@windels.cloud>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {TemplateView} from "../../../general/TemplateView";
+
+export class BaseTileView extends TemplateView {
+    // ignore other arguments
+    constructor(vm, viewClassForTile) {
+        super(vm);
+        this._viewClassForTile = viewClassForTile;
+        this._root = undefined;
+    }
+
+    root() {
+        return this._root;
+    }
+
+    render(t, vm) {
+        const tile = this.renderTile(t, vm);
+        const swapRoot = newRoot => {
+            this._root?.replaceWith(newRoot);
+            this._root = newRoot;
+        }
+        t.mapSideEffect(vm => vm.hasDateSeparator, hasDateSeparator => {
+            if (hasDateSeparator) {
+                const container = t.div([this._renderDateSeparator(t, vm)]);
+                swapRoot(container);
+                container.appendChild(tile);
+            } else {
+                swapRoot(tile);
+            }
+        });
+        return this._root;
+    }
+
+    _renderDateSeparator(t, vm) {
+        // if this needs any bindings, we need to use a subview
+        return t.div({className: "DateSeparator"}, t.time(vm.date));
+    }
+    
+    /* This is called by the parent ListView, which just has 1 listener for the whole list */
+    onClick() {}
+}

--- a/src/platform/web/ui/session/room/timeline/TextMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/TextMessageView.js
@@ -20,7 +20,7 @@ import {ReplyPreviewError, ReplyPreviewView} from "./ReplyPreviewView.js";
 
 export class TextMessageView extends BaseMessageView {
     renderMessageBody(t, vm) {
-        const time = t.time({className: {hidden: !vm.date}}, vm.date + " " + vm.time);
+        const time = t.time({className: {hidden: vm => !vm.time}}, vm => vm.time);
         const container = t.div({
             className: {
                 "Timeline_messageBody": true,


### PR DESCRIPTION
Fixes https://github.com/vector-im/hydrogen-web/issues/489
Currently looks like:
![image](https://user-images.githubusercontent.com/274386/175770508-aca664b2-f74d-4938-835e-6f10f4c2d7fa.png)

Missing:
 - [ ] jumps when at top and gap is filled
 - [ ] date separators look too much like announcement views
 - [ ] seems not stay at the bottom anymore when sending new messages
 - [ ] create shared date formatter in tile options
 	- does relative time
 	- use Int.DateFormatter