### PR TITLE
Also allow undefined, which means at the end of the paginated direction

### DIFF
--- a/src/matrix/room/timeline/persistence/GapWriter.js
+++ b/src/matrix/room/timeline/persistence/GapWriter.js
@@ -163,7 +163,7 @@ export class GapWriter {
         if (!Array.isArray(chunk)) {
             throw new Error("Invalid chunk in response");
         }
-        if (typeof end !== "string") {
+        if (typeof end !== "string" && typeof end !== "undefined") {
             throw new Error("Invalid end token in response");
         }
 


### PR DESCRIPTION
Fixes #765 
we already detect the end by chunk.length===0, so we just need to not throw