### PR TITLE
Add a couple consistent selectors to reference in tests

### DIFF
--- a/src/platform/web/ui/avatar.js
+++ b/src/platform/web/ui/avatar.js
@@ -31,7 +31,7 @@ export function renderStaticAvatar(vm, size, extraClasses = undefined) {
         avatarClasses += ` ${extraClasses}`;
     }
     const avatarContent = hasAvatar ? renderImg(vm, size) : text(vm.avatarLetter);
-    const avatar = tag.div({className: avatarClasses}, [avatarContent]);
+    const avatar = tag.div({className: avatarClasses, "data-testid": "avatar"}, [avatarContent]);
     if (hasAvatar) {
         setAttribute(avatar, "data-avatar-letter", vm.avatarLetter);
         setAttribute(avatar, "data-avatar-color", vm.avatarColorNumber);

--- a/src/platform/web/ui/session/room/timeline/BaseMediaView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMediaView.js
@@ -53,7 +53,7 @@ export class BaseMediaView extends BaseMessageView {
             children.push(progress);
         }
         return t.div({className: "Timeline_messageBody"}, [
-            t.div({className: "media", style: `max-width: ${vm.width}px`}, children),
+            t.div({className: "media", style: `max-width: ${vm.width}px`, "data-testid": "media"}, children),
             t.if(vm => vm.error, t => t.p({className: "error"}, vm.error))
         ]);
     }


### PR DESCRIPTION
Add a couple consistent selectors to reference in tests, example: https://github.com/matrix-org/matrix-public-archive/pull/29#discussion_r909492946

Related to https://github.com/vector-im/hydrogen-web/pull/690

Using `data-testid` because it seems generic out of the list from the following Cypress links. I'm not using Cypress but just trying to use something "standard". Feel free to suggest something better.

 - https://docs.cypress.io/guides/core-concepts/cypress-app#Uniqueness
 - https://docs.cypress.io/guides/references/best-practices#How-It-Works