### PR TITLE
Add more homeserver api

### DIFF
--- a/src/matrix/net/HomeServerApi.ts
+++ b/src/matrix/net/HomeServerApi.ts
@@ -271,6 +271,12 @@ export class HomeServerApi {
         return this._post(`/join/${encodeURIComponent(roomIdOrAlias)}`, {}, {}, options);
     }
 
+    invite(roomId: string, userId: string, options?: BaseRequestOptions): IHomeServerRequest {
+        return this._post(`/rooms/${encodeURIComponent(roomId)}/invite`, {}, {
+            user_id: userId
+        }, options);
+    }
+
     leave(roomId: string, options?: BaseRequestOptions): IHomeServerRequest {
         return this._post(`/rooms/${encodeURIComponent(roomId)}/leave`, {}, {}, options);
     }
@@ -296,6 +302,13 @@ export class HomeServerApi {
     claimDehydratedDevice(deviceId: string, options: BaseRequestOptions = {}): IHomeServerRequest {
         options.prefix = DEHYDRATION_PREFIX;
         return this._post(`/dehydrated_device/claim`, {}, {device_id: deviceId}, options);
+    }
+
+    searchProfile(searchTerm: string, limit?: number, options?: BaseRequestOptions): IHomeServerRequest {
+        return this._post(`/user_directory/search`, {}, {
+            limit: limit ?? 10,
+            search_term: searchTerm,
+        }, options);
     }
 
     profile(userId: string, options?: BaseRequestOptions): IHomeServerRequest {

--- a/src/matrix/room/BaseRoom.js
+++ b/src/matrix/room/BaseRoom.js
@@ -415,7 +415,7 @@ export class BaseRoom extends EventEmitter {
     }
 
     get type() {
-        return this._summary.data.type;
+        return this._summary.data.type ?? undefined;
     }
 
     get lastMessageTimestamp() {

--- a/src/matrix/room/Invite.js
+++ b/src/matrix/room/Invite.js
@@ -61,6 +61,10 @@ export class Invite extends EventEmitter {
         return this._inviteData.avatarColorId || this.id;
     }
 
+    get type() {
+        return this._inviteData.type ?? undefined;
+    }
+
     get timestamp() {
         return this._inviteData.timestamp;
     }
@@ -89,7 +93,7 @@ export class Invite extends EventEmitter {
         await this._platform.logger.wrapOrRun(log, "acceptInvite", async log => {
             this._accepting = true;
             this._emitChange("accepting");
-            await this._hsApi.join(this._roomId, {log}).response();
+            await this._hsApi.joinIdOrAlias(this.canonicalAlias ?? this._roomId, {log}).response();
         });
     }
 
@@ -189,7 +193,7 @@ export class Invite extends EventEmitter {
             roomId: this.id,
             isEncrypted: !!summaryData.encryption,
             isDirectMessage: summaryData.isDirectMessage,
-//            type: 
+            type: summaryData.type,
             name,
             avatarUrl,
             avatarColorId,

--- a/src/matrix/room/timeline/persistence/GapWriter.js
+++ b/src/matrix/room/timeline/persistence/GapWriter.js
@@ -163,7 +163,7 @@ export class GapWriter {
         if (!Array.isArray(chunk)) {
             throw new Error("Invalid chunk in response");
         }
-        if (typeof end !== "string") {
+        if (typeof end !== "string" && typeof end !== "undefined") {
             throw new Error("Invalid end token in response");
         }
 


### PR DESCRIPTION
This adds methods on HomeServerApi to search for a user profile and invite a user into a room. It also adds the `type` property to the room creation data and exposes that on BaseRoom.