### PR TITLE
Log the error when we can't get storage access

### DIFF
--- a/src/matrix/storage/idb/StorageFactory.ts
+++ b/src/matrix/storage/idb/StorageFactory.ts
@@ -42,6 +42,7 @@ async function requestPersistedStorage(): Promise<boolean> {
             await glob.document.requestStorageAccess();
             return true;
         } catch (err) {
+            console.warn("requestStorageAccess threw an error:", err);
             return false;
         }
     } else {

--- a/src/matrix/storage/idb/StorageFactory.ts
+++ b/src/matrix/storage/idb/StorageFactory.ts
@@ -21,7 +21,6 @@ import { exportSession, importSession, Export } from "./export";
 import { schema } from "./schema";
 import { detectWebkitEarlyCloseTxnBug } from "./quirks";
 import { ILogItem } from "../../../logging/types";
-import { LogLevel } from "../../../logging/LogFilter";
 
 const sessionName = (sessionId: string) => `hydrogen_session_${sessionId}`;
 const openDatabaseWithSessionId = function(sessionId: string, idbFactory: IDBFactory, localStorage: IDOMStorage, log: ILogItem) {
@@ -33,7 +32,7 @@ interface ServiceWorkerHandler {
     preventConcurrentSessionAccess: (sessionId: string) => Promise<void>;
 }
 
-async function requestPersistedStorage(log: ILogItem): Promise<boolean> {
+async function requestPersistedStorage(): Promise<boolean> {
     // don't assume browser so we can run in node with fake-idb
     const glob = this;
     if (glob?.navigator?.storage?.persist) {
@@ -43,8 +42,7 @@ async function requestPersistedStorage(log: ILogItem): Promise<boolean> {
             await glob.document.requestStorageAccess();
             return true;
         } catch (err) {
-            const item = log.log("requestStorageAccess threw an error:", LogLevel.Warn);
-            item.error = err;
+            console.warn("requestStorageAccess threw an error:", err);
             return false;
         }
     } else {
@@ -67,10 +65,10 @@ export class StorageFactory {
 
     async create(sessionId: string, log: ILogItem): Promise<Storage> {
         await this._serviceWorkerHandler?.preventConcurrentSessionAccess(sessionId);
-        requestPersistedStorage(log).then(persisted => {
+        requestPersistedStorage().then(persisted => {
             // Firefox lies here though, and returns true even if the user denied the request
             if (!persisted) {
-                log.log("no persisted storage, database can be evicted by browser:", LogLevel.Warn);
+                console.warn("no persisted storage, database can be evicted by browser");
             }
         });
 


### PR DESCRIPTION
This is quite useful when debugging why a session isn't working properly.