### PR TITLE
Fix .tmp being created in `/`

### DIFF
--- a/scripts/postcss/svg-builder.mjs
+++ b/scripts/postcss/svg-builder.mjs
@@ -36,7 +36,7 @@ export function buildColorizedSVG(svgLocation, primaryColor, secondaryColor) {
     const coloredSVGCode = getColoredSvgString(svgCode, primaryColor, secondaryColor);
     const fileName = svgLocation.match(/.+[/\\](.+\.svg)/)[1];
     const outputName = `${fileName.substring(0, fileName.length - 4)}-${createHash(coloredSVGCode)}.svg`;
-    const outputPath = resolve(__dirname, "../../.tmp");
+    const outputPath = resolve(__dirname, "./.tmp");
     try {
        mkdirSync(outputPath);
     }


### PR DESCRIPTION
We changed the extension of svg-builder to ".mjs" and that apparently changed `__dirname` to be the project root. 
Thus the icons were being produced at some other locations.