### PR TITLE
Fix sdk build failing after derived theme implementation

### DIFF
--- a/vite.sdk-assets-config.js
+++ b/vite.sdk-assets-config.js
@@ -36,7 +36,7 @@ export default mergeOptions(commonOptions, {
     plugins: [
         themeBuilder({
             themeConfig: {
-                themes: { element: "./src/platform/web/ui/css/themes/element" },
+                themes: ["./src/platform/web/ui/css/themes/element"],
                 default: "element",
             },
             compiledVariables,


### PR DESCRIPTION
Forgot to update the vite config