### PR TITLE
Gap fill from HS should halt on network disconnection

### DIFF
--- a/src/domain/session/room/timeline/tiles/GapTile.js
+++ b/src/domain/session/room/timeline/tiles/GapTile.js
@@ -38,6 +38,7 @@ export class GapTile extends SimpleTile {
             } catch (err) {
                 console.error(`room.fillGap(): ${err.message}:\n${err.stack}`);
                 this._error = err;
+                this._loading = false;
                 this.emitChange("error");
                 if (err instanceof ConnectionError) {
                     /*

--- a/src/domain/session/room/timeline/tiles/GapTile.js
+++ b/src/domain/session/room/timeline/tiles/GapTile.js
@@ -76,6 +76,7 @@ export class GapTile extends SimpleTile {
             }
             catch (e) {
                 if (e instanceof ConnectionError) {
+                    canFillMore = true;
                     // Don't increase depth because this gap fill was a noop
                     continue;
                 }

--- a/src/domain/session/room/timeline/tiles/GapTile.js
+++ b/src/domain/session/room/timeline/tiles/GapTile.js
@@ -111,8 +111,11 @@ export class GapTile extends SimpleTile {
 
     get error() {
         if (this._error) {
+            if (this._error instanceof ConnectionError) {
+                return { message: "Waiting for reconnection", showSpinner: true };
+            }
             const dir = this._entry.prev_batch ? "previous" : "next";
-            return `Could not load ${dir} messages: ${this._error.message}`;
+            return { message: `Could not load ${dir} messages: ${this._error.message}`, showSpinner: false };
         }
         return null;
     }

--- a/src/domain/session/room/timeline/tiles/GapTile.js
+++ b/src/domain/session/room/timeline/tiles/GapTile.js
@@ -143,6 +143,18 @@ export class GapTile extends SimpleTile {
         }
         return null;
     }
+
+    get currentAction() {
+        if (this.error) {
+            return this.error;
+        }
+        else if (this.isLoading) {
+            return "Loading";
+        }
+        else {
+            return "Not Loading";
+        }
+    }
 }
 
 import {FragmentBoundaryEntry} from "../../../../../matrix/room/timeline/entries/FragmentBoundaryEntry.js";

--- a/src/domain/session/room/timeline/tiles/GapTile.js
+++ b/src/domain/session/room/timeline/tiles/GapTile.js
@@ -77,6 +77,9 @@ export class GapTile extends SimpleTile {
                     // Don't increase depth because this gap fill was a noop
                     continue;
                 }
+                else {
+                    canFillMore = false;
+                }
             }
             depth = depth + 1;
         } while (depth < 10 && !this._siblingChanged && canFillMore && !this.isDisposed);
@@ -113,7 +116,7 @@ export class GapTile extends SimpleTile {
     }
 
     async _waitForReconnection() {
-        this.options.client.reconnector.connectionStatus.waitFor(status => status === ConnectionStatus.Online).promise;
+        await this.options.client.reconnector.connectionStatus.waitFor(status => status === ConnectionStatus.Online).promise;
     }
 
     get shape() {

--- a/src/platform/web/ui/css/themes/element/timeline.css
+++ b/src/platform/web/ui/css/themes/element/timeline.css
@@ -422,3 +422,12 @@ only loads when the top comes into view*/
 .GapView.isAtTop {
     padding: 52px 20px 12px 20px;
 }
+
+.GapView__container {
+    display: flex;
+    align-items: center;
+}
+
+.GapView__container .spinner {
+    margin-right: 10px;
+}

--- a/src/platform/web/ui/css/themes/element/timeline.css
+++ b/src/platform/web/ui/css/themes/element/timeline.css
@@ -422,12 +422,3 @@ only loads when the top comes into view*/
 .GapView.isAtTop {
     padding: 52px 20px 12px 20px;
 }
-
-.GapView__container {
-    display: flex;
-    align-items: center;
-}
-
-.GapView__container .spinner {
-    margin-right: 10px;
-}

--- a/src/platform/web/ui/session/room/timeline/GapView.js
+++ b/src/platform/web/ui/session/room/timeline/GapView.js
@@ -31,17 +31,7 @@ export class GapView extends TemplateView {
         };
         return t.li({ className }, [
             t.if(vm => vm.showSpinner, (t) => spinner(t)),
-            t.span(vm => {
-                if (vm.error) {
-                    return vm.error;
-                }
-                else if (vm.isLoading) {
-                    return "Loading";
-                }
-                else {
-                    return "Not Loading";
-                }
-            })
+            t.span(vm => vm.currentAction)
         ]);
     }
 

--- a/src/platform/web/ui/session/room/timeline/GapView.js
+++ b/src/platform/web/ui/session/room/timeline/GapView.js
@@ -30,24 +30,18 @@ export class GapView extends TemplateView {
             isAtTop: vm => vm.isAtTop,
         };
         return t.li({ className }, [
-            t.map(vm => vm.isLoading,
-                (isLoading, t, vm) => {
-                    let elements;
-                    const error = vm.error;
-                    if (error) {
-                        elements = [t.strong(() => error.message)]; 
-                        if (error.showSpinner) {
-                            elements.unshift(spinner(t));
-                        }
-                    }
-                    else if (isLoading) {
-                        elements = [spinner(t), t.span(vm.i18n`Loading more messages …`)];
-                    }
-                    else {
-                        elements = t.span(vm.i18n`Not loading!`);
-                    }
-                    return t.div({ className: "GapView__container" }, elements);
-                })
+            t.if(vm => vm.showSpinner, (t) => spinner(t)),
+            t.span(vm => {
+                if (vm.error) {
+                    return vm.error;
+                }
+                else if (vm.isLoading) {
+                    return "Loading";
+                }
+                else {
+                    return "Not Loading";
+                }
+            })
         ]);
     }
 

--- a/src/platform/web/ui/session/room/timeline/GapView.js
+++ b/src/platform/web/ui/session/room/timeline/GapView.js
@@ -29,10 +29,24 @@ export class GapView extends TemplateView {
             isLoading: vm => vm.isLoading,
             isAtTop: vm => vm.isAtTop,
         };
-        return t.li({className}, [
-            spinner(t),
-            t.div(vm => vm.isLoading ? vm.i18n`Loading more messages …` : vm.i18n`Not loading!`),
-            t.if(vm => vm.error, t => t.strong(vm => vm.error))
+        return t.li({ className }, [
+            t.map(vm => vm.error,
+                (error, t, vm) => {
+                    let elements;
+                    if (error) {
+                        elements = [t.strong(() => error.message)]; 
+                        if (error.showSpinner) {
+                            elements.unshift(spinner(t));
+                        }
+                    }
+                    else if (vm.isLoading) {
+                        elements = [spinner(t), t.span(vm.i18n`Loading more messages …`)];
+                    }
+                    else {
+                        elements = t.span(vm.i18n`Not loading!`);
+                    }
+                    return t.div({ className: "GapView__container" }, elements);
+                })
         ]);
     }
 

--- a/src/platform/web/ui/session/room/timeline/GapView.js
+++ b/src/platform/web/ui/session/room/timeline/GapView.js
@@ -30,16 +30,17 @@ export class GapView extends TemplateView {
             isAtTop: vm => vm.isAtTop,
         };
         return t.li({ className }, [
-            t.map(vm => vm.error,
-                (error, t, vm) => {
+            t.map(vm => vm.isLoading,
+                (isLoading, t, vm) => {
                     let elements;
+                    const error = vm.error;
                     if (error) {
                         elements = [t.strong(() => error.message)]; 
                         if (error.showSpinner) {
                             elements.unshift(spinner(t));
                         }
                     }
-                    else if (vm.isLoading) {
+                    else if (isLoading) {
                         elements = [spinner(t), t.span(vm.i18n`Loading more messages …`)];
                     }
                     else {


### PR DESCRIPTION
and should resume when connection is regained
This PR:
- Wait for network reconnection before retrying gap fill
- UI Improvements:
   - Errors can optionally show a spinner (eg when waiting for reconnection)
   - Other errors show no spinner
   - Show either "Not Loading" or the error itself but not both
   - Not Loading should not show a spinner