### PR TITLE
Improve error handling in the UI and logs

### DIFF
--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -334,8 +334,7 @@ export class Platform {
 
     async replaceStylesheet(newPath, log) {
         const error = await this.logger.wrapOrRun(log, { l: "replaceStylesheet", location: newPath, }, async (l) => {
-            let resolve, error;
-            const promise = new Promise(r => resolve = r);
+            let error;
             const head = document.querySelector("head");
             // remove default theme 
             document.querySelectorAll(".theme").forEach(e => e.remove());
@@ -345,14 +344,16 @@ export class Platform {
             styleTag.rel = "stylesheet";
             styleTag.type = "text/css";
             styleTag.className = "theme";
-            styleTag.onerror = () => {
-                error = new Error(`Failed to load stylesheet from ${newPath}`);
-                l.catch(error);
-                resolve();
-            };
-            styleTag.onload = () => {
-                resolve();
-            };
+            const promise = new Promise(resolve => {
+                styleTag.onerror = () => {
+                    error = new Error(`Failed to load stylesheet from ${newPath}`);
+                    l.catch(error);
+                    resolve();
+                };
+                styleTag.onload = () => {
+                    resolve();
+                };
+            });
             head.appendChild(styleTag);
             await promise;
             return error;

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -192,7 +192,7 @@ export class Platform {
                     await this._themeLoader?.init(manifests, log);
                     const { themeName, themeVariant } = await this._themeLoader.getActiveTheme();
                     log.log({ l: "Active theme", name: themeName, variant: themeVariant });
-                    this._themeLoader.setTheme(themeName, themeVariant, log);
+                    await this._themeLoader.setTheme(themeName, themeVariant, log);
                 }
             });
         } catch (err) {
@@ -332,17 +332,31 @@ export class Platform {
         return this._themeLoader;
     }
 
-    replaceStylesheet(newPath) {
-        const head = document.querySelector("head");
-        // remove default theme 
-        document.querySelectorAll(".theme").forEach(e => e.remove());
-        // add new theme
-        const styleTag = document.createElement("link");
-        styleTag.href = newPath;
-        styleTag.rel = "stylesheet";
-        styleTag.type = "text/css";
-        styleTag.className = "theme";
-        head.appendChild(styleTag);
+    async replaceStylesheet(newPath, log) {
+        await this.logger.wrapOrRun(log, { l: "replaceStylesheet", location: newPath, }, async (l) => {
+            let resolve;
+            const promise = new Promise(r => resolve = r);
+            const head = document.querySelector("head");
+            // remove default theme 
+            document.querySelectorAll(".theme").forEach(e => e.remove());
+            // add new theme
+            const styleTag = document.createElement("link");
+            styleTag.href = newPath;
+            styleTag.rel = "stylesheet";
+            styleTag.type = "text/css";
+            styleTag.className = "theme";
+            styleTag.onerror = () => {
+                const error = new Error(`Failed to load stylesheet at ${newPath}`);
+                l.catch(error);
+                resolve();
+                throw error
+            };
+            styleTag.onload = () => {
+                resolve();
+            };
+            head.appendChild(styleTag);
+            await promise;
+        });
     }
 
     get description() {

--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -333,8 +333,8 @@ export class Platform {
     }
 
     async replaceStylesheet(newPath, log) {
-        await this.logger.wrapOrRun(log, { l: "replaceStylesheet", location: newPath, }, async (l) => {
-            let resolve;
+        const error = await this.logger.wrapOrRun(log, { l: "replaceStylesheet", location: newPath, }, async (l) => {
+            let resolve, error;
             const promise = new Promise(r => resolve = r);
             const head = document.querySelector("head");
             // remove default theme 
@@ -346,17 +346,20 @@ export class Platform {
             styleTag.type = "text/css";
             styleTag.className = "theme";
             styleTag.onerror = () => {
-                const error = new Error(`Failed to load stylesheet at ${newPath}`);
+                error = new Error(`Failed to load stylesheet from ${newPath}`);
                 l.catch(error);
                 resolve();
-                throw error
             };
             styleTag.onload = () => {
                 resolve();
             };
             head.appendChild(styleTag);
             await promise;
+            return error;
         });
+        if (error) {
+            throw error;
+        }
     }
 
     get description() {

--- a/src/platform/web/dom/request/fetch.js
+++ b/src/platform/web/dom/request/fetch.js
@@ -119,10 +119,10 @@ export function createFetchRequest(createTimeout, serviceWorkerHandler) {
                     body = await response.text();
                 }
             } catch (err) {
-                // some error pages return html instead of json, ignore error
-                if (!(err.name === "SyntaxError" && status >= 400)) {
-                    throw err;
+                if (err.name === "SyntaxError" && status >= 400) {
+                    throw new ConnectionError(`${method} ${url}: Failed to fetch JSON file!`);
                 }
+                throw err;
             }
             return {status, body};
         }, err => {

--- a/src/platform/web/dom/request/fetch.js
+++ b/src/platform/web/dom/request/fetch.js
@@ -119,10 +119,11 @@ export function createFetchRequest(createTimeout, serviceWorkerHandler) {
                     body = await response.text();
                 }
             } catch (err) {
-                if (err.name === "SyntaxError" && status >= 400) {
-                    throw new ConnectionError(`${method} ${url}: Failed to fetch JSON file!`);
+                // some error pages return html instead of json, ignore error
+                // detect these ignored errors from the response status 
+                if (!(err.name === "SyntaxError" && status >= 400)) {
+                    throw err;
                 }
-                throw err;
             }
             return {status, body};
         }, err => {

--- a/src/platform/web/theming/ThemeLoader.ts
+++ b/src/platform/web/theming/ThemeLoader.ts
@@ -21,6 +21,7 @@ import type {Variant, ThemeInformation} from "./parsers/types";
 import type {ThemeManifest} from "../../types/theme";
 import type {ILogItem} from "../../../logging/types";
 import type {Platform} from "../Platform.js";
+import {LogLevel} from "../../../logging/LogFilter";
 
 export class ThemeLoader {
     private _platform: Platform;
@@ -46,7 +47,7 @@ export class ThemeLoader {
                 const result = results[i];
                 if (result.status === "rejected") {
                     console.error(`Failed to load manifest at ${manifestLocations[i]}, reason: ${result.reason}`);
-                    log.log({ l: "Manifest fetch failed", location: manifestLocations[i], reason: result.reason });
+                    log.log({ l: "Manifest fetch failed", location: manifestLocations[i], reason: result.reason }, LogLevel.Error);
                     failedManifestLoads.push(manifestLocations[i])
                     continue;
                 }

--- a/src/platform/web/theming/ThemeLoader.ts
+++ b/src/platform/web/theming/ThemeLoader.ts
@@ -88,8 +88,8 @@ export class ThemeLoader {
         });
     }
 
-    setTheme(themeName: string, themeVariant?: "light" | "dark" | "default", log?: ILogItem) {
-        this._platform.logger.wrapOrRun(log, { l: "change theme", name: themeName, variant: themeVariant }, () => {
+    async setTheme(themeName: string, themeVariant?: "light" | "dark" | "default", log?: ILogItem) {
+        await this._platform.logger.wrapOrRun(log, { l: "change theme", name: themeName, variant: themeVariant }, async (l) => {
             let cssLocation: string, variables: Record<string, string>;
             let themeDetails = this._themeMapping[themeName];
             if ("id" in themeDetails) {
@@ -103,7 +103,7 @@ export class ThemeLoader {
                 cssLocation = themeDetails[themeVariant].cssLocation;
                 variables = themeDetails[themeVariant].variables;
             }
-            this._platform.replaceStylesheet(cssLocation);
+            await this._platform.replaceStylesheet(cssLocation, l);
             if (variables) {
                 log?.log({l: "Derived Theme", variables});
                 this._injectCSSVariables(variables);


### PR DESCRIPTION
The following cases are handled:
- Error is shown in the UI when all the theme manifests failed to load (in addition to them being logged).
- If some manifests failed to load but at least one manifest is available, the errors are not shown in UI but all such errors are logged.
- If after parsing all the themes, no themes are available (for eg due to them all missing the "name" field) then an error saying as much is shown in the UI.
- If some themes failed to parse but at least one is available, no errors are shown in the UI although they are still logged.
- If when setting a particular theme, the css file added using the `link` element failed to load, an error is shown in the UI. This is limited to when the theme is set by `Platform.init` method. 