### PR TITLE
Fix/dynamic OIDC registration

### DIFF
--- a/src/domain/login/CompleteOIDCLoginViewModel.js
+++ b/src/domain/login/CompleteOIDCLoginViewModel.js
@@ -63,6 +63,7 @@ export class CompleteOIDCLoginViewModel extends ViewModel {
 
         const oidcApi = new OidcApi({
             issuer,
+            clientConfigs: this.platform.config.oidc.clientConfigs,
             clientId,
             request: this._request,
             encoding: this._encoding,

--- a/src/domain/login/StartOIDCLoginViewModel.js
+++ b/src/domain/login/StartOIDCLoginViewModel.js
@@ -26,6 +26,7 @@ export class StartOIDCLoginViewModel extends ViewModel {
         this._homeserver = options.loginOptions.homeserver;
         this._api = new OidcApi({
             issuer: this._issuer,
+            clientConfigs: this._platform.config.oidc.clientConfigs,
             request: this.platform.request,
             encoding: this.platform.encoding,
             crypto: this.platform.crypto,

--- a/src/matrix/Client.js
+++ b/src/matrix/Client.js
@@ -135,6 +135,7 @@ export class Client {
                 try {
                     const oidcApi = new OidcApi({
                         issuer,
+                        clientConfigs: this._platform.config.oidc.clientConfigs,
                         request: this._platform.request,
                         encoding: this._platform.encoding,
                         crypto: this._platform.crypto,
@@ -265,6 +266,7 @@ export class Client {
         if (sessionInfo.oidcIssuer) {
             const oidcApi = new OidcApi({
                 issuer: sessionInfo.oidcIssuer,
+                clientConfigs: this._platform.config.oidc.clientConfigs,
                 clientId: sessionInfo.oidcClientId,
                 request: this._platform.request,
                 encoding: this._platform.encoding,
@@ -487,6 +489,7 @@ export class Client {
                 await hsApi.logout({log}).response();
                 const oidcApi = new OidcApi({
                     issuer: sessionInfo.oidcIssuer,
+                    clientConfigs: this._platform.config.oidc.clientConfigs,
                     clientId: sessionInfo.oidcClientId,
                     request: this._platform.request,
                     encoding: this._platform.encoding,

--- a/src/matrix/Client.js
+++ b/src/matrix/Client.js
@@ -306,6 +306,9 @@ export class Client {
             userId: sessionInfo.userId,
             homeserver: sessionInfo.homeServer,
         };
+        if (sessionInfo.accountManagementUrl) {
+            filteredSessionInfo.accountManagementUrl = sessionInfo.accountManagementUrl;
+        }
         const olm = await this._olmPromise;
         let olmWorker = null;
         if (this._workerPromise) {

--- a/src/platform/web/assets/config.json
+++ b/src/platform/web/assets/config.json
@@ -10,7 +10,7 @@
     "clientConfigs": {
       "https://id.thirdroom.io/realms/thirdroom/": {
         "client_id": "thirdroom",
-        "uris": ["http:localhost:3000", "https://thirdroom.io"]
+        "uris": ["http://localhost:3000", "https://thirdroom.io"]
       }
     }
   }

--- a/src/platform/web/assets/config.json
+++ b/src/platform/web/assets/config.json
@@ -5,5 +5,13 @@
     "applicationServerKey": "BC-gpSdVHEXhvHSHS0AzzWrQoukv2BE7KzpoPO_FfPacqOo3l1pdqz7rSgmB04pZCWaHPz7XRe6fjLaC-WPDopM"
   },
   "defaultHomeServer": "matrix.org",
-  "bugReportEndpointUrl": "https://element.io/bugreports/submit"
+  "bugReportEndpointUrl": "https://element.io/bugreports/submit",
+  "oidc": {
+    "clientConfigs": {
+      "https://id.thirdroom.io/realms/thirdroom/": {
+        "client_id": "thirdroom",
+        "uris": ["http:localhost:3000", "https://thirdroom.io"]
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adds OIDC accountManagmentUrl to session.sessionInfo so it will available in `Session`.

Map statically registered redirect uris to oidc client_id so client dynamic registration doesn't always pick single client_id for same issuer.
And moves oidc clientConfigs to app configs so we don't need to update sdk to change these configs. 