### PR TITLE
Fix OIDC logout

### DIFF
--- a/src/matrix/Client.js
+++ b/src/matrix/Client.js
@@ -490,7 +490,14 @@ export class Client {
                         encoding: this._platform.encoding,
                         crypto: this._platform.crypto,
                     });
-                    await oidcApi.revokeToken({ token: sessionInfo.accessToken, type: "access_token" });
+
+                    // if access token revocation fails then we still want to try and revoke the refresh token
+                    try {
+                        await oidcApi.revokeToken({ token: sessionInfo.accessToken, type: "access_token" });
+                    } catch (err) {
+                        console.error(err);
+                    }
+        
                     if (sessionInfo.refreshToken) {
                         await oidcApi.revokeToken({ token: sessionInfo.refreshToken, type: "refresh_token" });
                     }

--- a/src/matrix/Client.js
+++ b/src/matrix/Client.js
@@ -490,9 +490,9 @@ export class Client {
                         encoding: this._platform.encoding,
                         crypto: this._platform.crypto,
                     });
-                    await oidcApi.revokeToken({ token: sessionInfo.accessToken, type: "access" });
+                    await oidcApi.revokeToken({ token: sessionInfo.accessToken, type: "access_token" });
                     if (sessionInfo.refreshToken) {
-                        await oidcApi.revokeToken({ token: sessionInfo.refreshToken, type: "refresh" });
+                        await oidcApi.revokeToken({ token: sessionInfo.refreshToken, type: "refresh_token" });
                     }
                 } else {
                     const hsApi = new HomeServerApi({

--- a/src/matrix/net/OidcApi.ts
+++ b/src/matrix/net/OidcApi.ts
@@ -307,7 +307,7 @@ export class OidcApi<N extends object = SegmentType> {
     async revokeToken({
         token,
         type,
-    }: { token: string, type: "refresh" | "access" }): Promise<void> {
+    }: { token: string, type: "refresh_token" | "access_token" }): Promise<void> {
         const revocationEndpoint = await this.revocationEndpoint();
         if (!revocationEndpoint) {
             return;

--- a/src/matrix/net/OidcApi.ts
+++ b/src/matrix/net/OidcApi.ts
@@ -325,7 +325,6 @@ export class OidcApi<N extends object = SegmentType> {
         const req = this._requestFn(revocationEndpoint, {
             method: "POST",
             headers,
-            format: "json",
             body,
         });
 

--- a/src/matrix/net/OidcApi.ts
+++ b/src/matrix/net/OidcApi.ts
@@ -314,7 +314,7 @@ export class OidcApi<N extends object = SegmentType> {
         }
 
         const params = new URLSearchParams();
-        params.append("token_type", type);
+        params.append("token_type_hint", type);
         params.append("token", token);
         params.append("client_id", await this.clientId());
         const body = params.toString();


### PR DESCRIPTION
This PR fix when calling startLogout function fails at logout as it was calling homeserver /logout api before revoking oidc access token.

Also fix where `oidcApi.revokeToken` method was considering response format to be json and failing as revoken token api only send response with statusCode.