### PR TITLE
Fix SDK asset build failing on Windows

### DIFF
--- a/scripts/build-plugins/rollup-plugin-build-themes.js
+++ b/scripts/build-plugins/rollup-plugin-build-themes.js
@@ -13,11 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-// Use the path implementation native to the platform so it plays well with
-// resolving the `__dirname` and `C:\` against the relative location (think
-// Windows and backslashes).
+// Use the path implementation native to the platform so paths from disk play
+// well with resolving against the relative location (think Windows `C:\` and
+// backslashes).
 const path = require('path');
 // Use the posix (forward slash) implementation when working with `import` paths
+// to reference resources
 const posixPath = require('path').posix;
 const {optimize} = require('svgo');
 

--- a/scripts/build-plugins/rollup-plugin-build-themes.js
+++ b/scripts/build-plugins/rollup-plugin-build-themes.js
@@ -24,7 +24,6 @@ const {optimize} = require('svgo');
 
 async function readCSSSource(location) {
     const fs = require("fs").promises;
-    const path = require("path");
     const resolvedLocation = path.resolve(__dirname, "../../", `${location}/theme.css`);
     const data = await fs.readFile(resolvedLocation);
     return data;

--- a/scripts/build-plugins/rollup-plugin-build-themes.js
+++ b/scripts/build-plugins/rollup-plugin-build-themes.js
@@ -25,7 +25,6 @@ async function readCSSSource(location) {
     const fs = require("fs").promises;
     const path = require("path");
     const resolvedLocation = path.resolve(__dirname, "../../", `${location}/theme.css`);
-    console.log('resolvedLocation', resolvedLocation);
     const data = await fs.readFile(resolvedLocation);
     return data;
 }

--- a/scripts/build-plugins/rollup-plugin-build-themes.js
+++ b/scripts/build-plugins/rollup-plugin-build-themes.js
@@ -13,12 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-const path = require('path').posix;
+// Use the path implementation native to the platform so it plays well with
+// resolving the `__dirname` and `C:\` against the relative location (think
+// Windows and backslashes).
+const path = require('path');
+// Use the posix (forward slash) implementation when working with `import` paths
+const posixPath = require('path').posix;
 const {optimize} = require('svgo');
 
 async function readCSSSource(location) {
     const fs = require("fs").promises;
+    const path = require("path");
     const resolvedLocation = path.resolve(__dirname, "../../", `${location}/theme.css`);
+    console.log('resolvedLocation', resolvedLocation);
     const data = await fs.readFile(resolvedLocation);
     return data;
 }
@@ -238,7 +245,7 @@ module.exports = function buildThemes(options) {
                     switch (file) {
                         case "index.js": {
                             const isDark = variants[variant].dark;
-                            return `import "${path.resolve(`${location}/theme.css`)}${isDark? "?dark=true": ""}";` +
+                            return `import "${posixPath.resolve(`${location}/theme.css`)}${isDark? "?dark=true": ""}";` +
                                 `import "@theme/${theme}/${variant}/variables.css"`;
                         }
                         case "variables.css": { 


### PR DESCRIPTION
Fix SDK asset build failing on Windows

```
$ yarn run vite build -c vite.sdk-assets-config.js
yarn run v1.22.18
$ C:\Users\MLM\Documents\GitHub\element\hydrogen-web\node_modules\.bin\vite build -c vite.sdk-assets-config.js
locally linked postcss
cleanUrl(id) C:/Users/MLM/Documents/GitHub/element/hydrogen-web/src/platform/web/ui/css/themes/element/theme.css C:/Users/MLM/Documents/GitHub/element/hydrogen-web/src/platform/web/ui/css/themes/element/theme.css?type=runtime
[build-themes] Could not load C:/Users/MLM/Documents/GitHub/element/hydrogen-web/src/platform/web/ui/css/themes/element/theme.css?variant=light: ENOENT: no such file or directory, open 'C:\Users\MLM\Documents\GitHub\element\C:\Users\MLM\Documents\GitHub\element\hydrogen-web\src\platform\web\ui\css\themes\element\theme.css'
error during build:
Error: Could not load C:/Users/MLM/Documents/GitHub/element/hydrogen-web/src/platform/web/ui/css/themes/element/theme.css?variant=light: ENOENT: no such file or directory, open 'C:\Users\MLM\Documents\GitHub\element\C:\Users\MLM\Documents\GitHub\element\hydrogen-web\src\platform\web\ui\css\themes\element\theme.css'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Regressed in:
https://github.com/vector-im/hydrogen-web/pull/769/files#diff-5432b565e86d2514c825ed9972c37ea19820bf12b5d8d3203fc9d4ea4654bd34L20 where the `const path = require('path');` was removed but we also started using `path` in more places which needed the same treatment.

When making the fix, we also have to make sure we don't also regress:
https://github.com/vector-im/hydrogen-web/pull/750