### PR TITLE
Find relations to remote events within the new remote events

### DIFF
--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -198,8 +198,10 @@ export class Timeline {
         if (!this._localEntries?.hasSubscriptions) {
             return;
         }
-        // find any local relations to this new remote event
-        for (const pee of this._localEntries) {
+        // find any local relations to these new remote events or maybe these
+        // new remote events reference one of the other new remote events we have.
+        const entryList = new ConcatList(entries, this._localEntries);
+        for (const pee of entryList) {
             // this will work because we set relatedEventId when removing remote echos
             if (pee.relatedEventId) {
                 const relationTarget = entries.find(e => e.id === pee.relatedEventId);

--- a/src/matrix/room/timeline/Timeline.js
+++ b/src/matrix/room/timeline/Timeline.js
@@ -666,7 +666,7 @@ export function tests() {
                 relatedEventId: reactionEntry.id
             }}));
             await poll(() => timeline.entries.length >= 3);
-            assert.equal(messageEntry.pendingAnnotations.get("👋").count, -1);
+            assert.equal(messageEntry.pendingAnnotations.get("👋").count, 0);
         },
         "local reaction gets applied after remote echo is added to timeline": async assert => {
             const messageEntry = new EventEntry({event: withTextBody("hi bob!", withSender(alice, createEvent("m.room.message", "!abc"))),


### PR DESCRIPTION
Find relations to remote events within the new remote events. This allows the reactions to appear in the [Matrix public archive](https://github.com/matrix-org/matrix-public-archive) since we provide one big list of events to display.

Split off from https://github.com/vector-im/hydrogen-web/pull/653


### Dev notes

```
yarn impunity --entry-point src/matrix/room/timeline/Timeline.js --force-esm-dirs lib/ src/
```

Can't run a single test: https://github.com/bwindels/impunity/issues/17