### PR TITLE
Remove unused conflicting generic styles

### DIFF
--- a/src/platform/web/ui/css/room.css
+++ b/src/platform/web/ui/css/room.css
@@ -23,10 +23,6 @@ limitations under the License.
     flex: 1;
 }
 
-.middle-header button {
-    display: block;
-}
-
 .middle-header .room-description {
     flex: 1;
     min-width: 0;


### PR DESCRIPTION
Remove unused conflicting generic styles.

Split off from https://github.com/vector-im/hydrogen-web/pull/653

These styles were conflicting with some in the Matrix public archive and instead of adjusting in that project, they seem unused here anyway so we can simplify and remove here.

For reference, the style here conflicts with the `.room-header-change-dates-button` styles in https://github.com/matrix-org/matrix-public-archive/pull/53