### PR TITLE
Make no `content` PL fallback to `0`

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -17,6 +17,7 @@ limitations under the License.
 export {Platform} from "./platform/web/Platform.js";
 export {Client, LoadStatus} from "./matrix/Client.js";
 export {RoomStatus} from "./matrix/room/common";
+export {PowerLevels} from "./matrix/room/PowerLevels.js";
 // export main view & view models
 export {createNavigation, createRouter} from "./domain/navigation/index";
 export {RootViewModel} from "./domain/RootViewModel.js";

--- a/src/matrix/room/PowerLevels.js
+++ b/src/matrix/room/PowerLevels.js
@@ -75,11 +75,11 @@ export class PowerLevels {
     }
 
     _getEventTypeLevel(eventType) {
-        const level = this._plEvent?.content.events?.[eventType];
+        const level = this._plEvent?.content?.events?.[eventType];
         if (typeof level === "number") {
             return level;
         } else {
-            const level = this._plEvent?.content.events_default;
+            const level = this._plEvent?.content?.events_default;
             if (typeof level === "number") {
                 return level;
             } else {


### PR DESCRIPTION
Make no `content` PL fallback to `0`. A valid PL event will have `content` but when you're just stubbing a PL event with an empty object `{}`, it doesn't need to exist and we can just as easily fallback to `0` PL level.

Split off from https://github.com/vector-im/hydrogen-web/pull/653

Changes necessary for https://github.com/matrix-org/matrix-public-archive/pull/57