### PR TITLE
Allow the `DisabledComposerView` to have a HTML templated description

### DIFF
--- a/src/platform/web/ui/session/room/DisabledComposerView.js
+++ b/src/platform/web/ui/session/room/DisabledComposerView.js
@@ -17,7 +17,7 @@ limitations under the License.
 import {TemplateView} from "../../general/TemplateView";
 
 export class DisabledComposerView extends TemplateView {
-    render(t) {
-        return t.div({className: "DisabledComposerView"}, t.h3(vm => vm.description));
+    render(t, vm) {
+        return t.div({className: "DisabledComposerView"}, t.h3(vm.description));
     }
 }


### PR DESCRIPTION
Allow the `DisabledComposerView` to have a HTML templated description. Changes used in https://github.com/matrix-org/matrix-public-archive/pull/54 so we can add a link.

```js
description: [
      `You're viewing an archive of events from ${dateString}. Use a `,
      tag.a(
        {
          href: matrixPublicArchiveURLCreator.permalinkForRoomId(roomData.id),
          rel: 'noopener',
          target: '_blank',
        },
        ['Matrix client']
      ),
      ` to start chatting in this room.`,
    ],
```

The previous behavior is still possible by providing `description: (vm) => vm.description`.

### Dev notes

 - `LowerPowerLevelViewModel`
 - `ArchivedViewModel`