### PR TITLE
Log errors when mounting views to the console for easier reference

### DIFF
--- a/src/platform/web/ui/general/utils.ts
+++ b/src/platform/web/ui/general/utils.ts
@@ -22,6 +22,9 @@ export function mountView(view: IView, mountArgs?: IMountArgs): ViewNode {
     try {
         node = view.mount(mountArgs);
     } catch (err) {
+        // Log it to the console so it's easy to reference
+        console.error(err);
+        // Then render our error boundary to the DOM
         node = errorToDOM(err);
     }
     return node;


### PR DESCRIPTION
Also log errors when mounting views to the console for easier reference instead of just having it in the DOM at the component error boundary.

From the console, I can click the source references in the stack trace to jump to the spot in the code where things are going wrong. Looking a the console also gives an easy way to check for errors anywhere on the page.

It also helps with the problem of the error not having enough space to be read in some components since it overflows off-screen.

![Error overflowing the component and hard to read](https://user-images.githubusercontent.com/558581/190710934-bbe60afc-fb7f-456b-b108-f82af3240f44.png)




---

Split off from https://github.com/vector-im/hydrogen-web/pull/653