### PR TITLE
Add `data-event-id` to `AnnouncementView` so it appears for state events in the timeline

### DIFF
--- a/src/platform/web/ui/session/room/timeline/AnnouncementView.js
+++ b/src/platform/web/ui/session/room/timeline/AnnouncementView.js
@@ -22,8 +22,11 @@ export class AnnouncementView extends TemplateView {
         super(vm);
     }
 
-    render(t) {
-        return t.li({className: "AnnouncementView"}, t.div(vm => vm.announcement));
+    render(t, vm) {
+        return t.li({
+            className: "AnnouncementView",
+            'data-event-id': vm.eventId
+        }, t.div(vm => vm.announcement));
     }
     
     /* This is called by the parent ListView, which just has 1 listener for the whole list */


### PR DESCRIPTION
Add `data-event-id` to `AnnouncementView` so it appears for state events in the timeline

Follow-up to https://github.com/vector-im/hydrogen-web/pull/690 which added it to `BaseMessageView`

Split off from https://github.com/vector-im/hydrogen-web/pull/653