### PR TITLE
don't ignore end-of-ICE candidates

### DIFF
--- a/src/matrix/calls/PeerCall.ts
+++ b/src/matrix/calls/PeerCall.ts
@@ -823,7 +823,7 @@ export class PeerCall implements IDisposable {
                 (candidate.sdpMid === null || candidate.sdpMid === undefined) &&
                 (candidate.sdpMLineIndex === null || candidate.sdpMLineIndex === undefined)
             ) {
-                logItem = log.log(`Got remote ICE end-of-ICE candidates`);
+                logItem = log.log(`Got remote end-of-ICE candidates`);
             }
             else {
                 logItem = log.log(`Adding remote ICE ${candidate.sdpMid} candidate: ${candidate.candidate}`);

--- a/src/matrix/calls/PeerCall.ts
+++ b/src/matrix/calls/PeerCall.ts
@@ -818,14 +818,16 @@ export class PeerCall implements IDisposable {
 
     private async addIceCandidates(candidates: RTCIceCandidate[], log: ILogItem): Promise<void> {
         for (const candidate of candidates) {
+            let logItem;
             if (
                 (candidate.sdpMid === null || candidate.sdpMid === undefined) &&
                 (candidate.sdpMLineIndex === null || candidate.sdpMLineIndex === undefined)
             ) {
-                log.log(`Ignoring remote ICE candidate with no sdpMid or sdpMLineIndex`);
-                continue;
+                logItem = log.log(`Got remote ICE end-of-ICE candidates`);
             }
-            const logItem = log.log(`Adding remote ICE ${candidate.sdpMid} candidate: ${candidate.candidate}`);
+            else {
+                logItem = log.log(`Adding remote ICE ${candidate.sdpMid} candidate: ${candidate.candidate}`);
+            }
             try {
                 await this.peerConnection.addIceCandidate(candidate);
             } catch (err) {


### PR DESCRIPTION
an empty ICE candidate is the horrible way that webrtc signals that ICE is completed. therefore we should pass it to the stack; not doing so might contribute to ICE failures.

a partial port of https://github.com/matrix-org/matrix-js-sdk/commit/6e25b133123dbc49480b641937eb18102309e592#diff-df33fb6c18a9b5896cd500875824d6c10980d42c92b21cedac6d8f570a8d52b7R2410