### PR TITLE
Implement TURN

### DIFF
--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -561,14 +561,14 @@ export class Session {
     }
 
     async _updateTurnServers() {
-        const turnServersData = await this._hsApi.getTurnServers().response();
+        const turnServerData = await this._hsApi.getTurnServer().response();
         this._callHandler.setTurnServers({
             urls: turnServerData.uris,
             username: turnServerData.username,
             credential: turnServerData.password,
         });
-        if (turnServersData.ttl > 0) {
-            setTimeout(this._updateTurnServers, turnServersData.ttl * 1000);
+        if (turnServerData.ttl > 0) {
+            setTimeout(this._updateTurnServers, turnServerData.ttl * 1000);
         }
     }
 

--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -513,6 +513,7 @@ export class Session {
             // TODO: what can we do if this throws?
             await txn.complete();
         }
+        await this._updateTurnServers();
         // enable session backup, this requests the latest backup version
         if (!this._keyBackup.get()) {
             if (dehydratedDevice) {
@@ -556,6 +557,18 @@ export class Session {
                 roomOperationsByType = groupBy(roomOperations, r => r.type);
             }
             room.start(roomOperationsByType, log);
+        }
+    }
+
+    async _updateTurnServers() {
+        const turnServersData = await this._hsApi.getTurnServers().response();
+        this._callHandler.setTurnServers({
+            urls: turnServerData.uris,
+            username: turnServerData.username,
+            credential: turnServerData.password,
+        });
+        if (turnServersData.ttl > 0) {
+            setTimeout(this._updateTurnServers, turnServersData.ttl * 1000);
         }
     }
 

--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -488,6 +488,8 @@ export class Session {
         this._megolmDecryption = undefined;
         this._e2eeAccount?.dispose();
         this._e2eeAccount = undefined;
+        this._callHandler?.dispose();
+        this._callHandler = undefined;
         for (const room of this._rooms.values()) {
             room.dispose();
         }

--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -513,7 +513,6 @@ export class Session {
             // TODO: what can we do if this throws?
             await txn.complete();
         }
-        await this._updateTurnServers();
         // enable session backup, this requests the latest backup version
         if (!this._keyBackup.get()) {
             if (dehydratedDevice) {
@@ -557,18 +556,6 @@ export class Session {
                 roomOperationsByType = groupBy(roomOperations, r => r.type);
             }
             room.start(roomOperationsByType, log);
-        }
-    }
-
-    async _updateTurnServers() {
-        const turnServerData = await this._hsApi.getTurnServer().response();
-        this._callHandler.setTurnServers([{
-            urls: turnServerData.uris,
-            username: turnServerData.username,
-            credential: turnServerData.password,
-        }]);
-        if (turnServerData.ttl > 0) {
-            setTimeout(this._updateTurnServers, turnServerData.ttl * 1000);
         }
     }
 

--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -101,9 +101,6 @@ export class Session {
             ownDeviceId: sessionInfo.deviceId,
             ownUserId: sessionInfo.userId,
             logger: this._platform.logger,
-            turnServers: [{
-                urls: ["stun:turn.matrix.org"],
-            }],
             forceTURN: false,
         });
         this._roomStateHandler = new RoomStateHandlerSet();

--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -562,11 +562,11 @@ export class Session {
 
     async _updateTurnServers() {
         const turnServerData = await this._hsApi.getTurnServer().response();
-        this._callHandler.setTurnServers({
+        this._callHandler.setTurnServers([{
             urls: turnServerData.uris,
             username: turnServerData.username,
             credential: turnServerData.password,
-        });
+        }]);
         if (turnServerData.ttl > 0) {
             setTimeout(this._updateTurnServers, turnServerData.ttl * 1000);
         }

--- a/src/matrix/calls/CallHandler.ts
+++ b/src/matrix/calls/CallHandler.ts
@@ -40,7 +40,7 @@ import type {Clock} from "../../platform/web/dom/Clock";
 import type {RoomStateHandler} from "../room/state/types";
 import type {MemberSync} from "../room/timeline/persistence/MemberWriter";
 
-export type Options = Omit<GroupCallOptions, "emitUpdate" | "createTimeout"> & {
+export type Options = Omit<GroupCallOptions, "emitUpdate" | "createTimeout" | "turnServerSource"> & {
     clock: Clock
 };
 

--- a/src/matrix/calls/CallHandler.ts
+++ b/src/matrix/calls/CallHandler.ts
@@ -75,7 +75,7 @@ export class CallHandler implements RoomStateHandler {
         this._loadCallEntries(callEntries, txn);
     }
 
-    async setTurnServers(turnServers: RTCIceServer[]) {
+    setTurnServers(turnServers: RTCIceServer[]) {
         this.options.turnServers = turnServers;
         this.groupCallOptions.turnServers = turnServers;
         // TODO: we should update any ongoing peerconnections if the TURN server details have changed

--- a/src/matrix/calls/CallHandler.ts
+++ b/src/matrix/calls/CallHandler.ts
@@ -75,6 +75,12 @@ export class CallHandler implements RoomStateHandler {
         this._loadCallEntries(callEntries, txn);
     }
 
+    async setTurnServers(turnServers: RTCIceServer) {
+        this.options.turnServers = turnServers;
+        this.groupCallOptions.turnServers = turnServers;
+        // TODO: we should update any ongoing peerconnections if the TURN server details have changed
+    }
+
     private async _getLoadTxn(): Promise<Transaction> {
         const names = this.options.storage.storeNames;
         const txn = await this.options.storage.readTxn([

--- a/src/matrix/calls/CallHandler.ts
+++ b/src/matrix/calls/CallHandler.ts
@@ -75,7 +75,7 @@ export class CallHandler implements RoomStateHandler {
         this._loadCallEntries(callEntries, txn);
     }
 
-    async setTurnServers(turnServers: RTCIceServer) {
+    async setTurnServers(turnServers: RTCIceServer[]) {
         this.options.turnServers = turnServers;
         this.groupCallOptions.turnServers = turnServers;
         // TODO: we should update any ongoing peerconnections if the TURN server details have changed

--- a/src/matrix/calls/CallHandler.ts
+++ b/src/matrix/calls/CallHandler.ts
@@ -23,6 +23,7 @@ import {GroupCall} from "./group/GroupCall";
 import {makeId} from "../common";
 import {CALL_LOG_TYPE} from "./common";
 import {EVENT_TYPE as MEMBER_EVENT_TYPE, RoomMember} from "../room/members/RoomMember";
+import {TurnServerSource} from "./TurnServerSource";
 
 import type {LocalMedia} from "./LocalMedia";
 import type {Room} from "../room/Room";
@@ -57,6 +58,7 @@ export class CallHandler implements RoomStateHandler {
 
     constructor(private readonly options: Options) {
         this.groupCallOptions = Object.assign({}, this.options, {
+            turnServerSource: new TurnServerSource(this.options.hsApi, this.options.clock),
             emitUpdate: (groupCall, params) => this._calls.update(groupCall.id, params),
             createTimeout: this.options.clock.createTimeout,
             sessionId: this.sessionId
@@ -73,12 +75,6 @@ export class CallHandler implements RoomStateHandler {
         const txn = await this._getLoadTxn();
         const callEntries = await txn.calls.getByIntentAndRoom(intent, roomId);
         this._loadCallEntries(callEntries, txn);
-    }
-
-    setTurnServers(turnServers: RTCIceServer[]) {
-        this.options.turnServers = turnServers;
-        this.groupCallOptions.turnServers = turnServers;
-        // TODO: we should update any ongoing peerconnections if the TURN server details have changed
     }
 
     private async _getLoadTxn(): Promise<Transaction> {

--- a/src/matrix/calls/PeerCall.ts
+++ b/src/matrix/calls/PeerCall.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import {ObservableMap} from "../../observable/map/ObservableMap";
+import {BaseObservableValue} from "../../observable/value/BaseObservableValue";
 import {recursivelyAssign} from "../../utils/recursivelyAssign";
 import {Disposables, Disposable, IDisposable} from "../../utils/Disposables";
 import {WebRTC, PeerConnection, Transceiver, TransceiverDirection, Sender, Receiver, PeerConnectionEventMap} from "../../platform/types/WebRTC";
@@ -47,7 +48,7 @@ import type {
 export type Options = {
     webRTC: WebRTC,
     forceTURN: boolean,
-    turnServers: RTCIceServer[],
+    turnServer: BaseObservableValue<RTCIceServer>,
     createTimeout: TimeoutCreator,
     emitUpdate: (peerCall: PeerCall, params: any, log: ILogItem) => void;
     sendSignallingMessage: (message: SignallingMessage<MCallBase>, log: ILogItem) => Promise<void>;

--- a/src/matrix/calls/PeerCall.ts
+++ b/src/matrix/calls/PeerCall.ts
@@ -120,13 +120,11 @@ export class PeerCall implements IDisposable {
             [this.options.turnServer.get()],
             0
         );
-        // update turn servers when they change (see TurnServerSource) if possible
-        if (typeof this.peerConnection["setConfiguration"] === "function") {
-            this.disposables.track(this.options.turnServer.subscribe(turnServer => {
-                this.logItem.log({l: "updating turn server", turnServer})
-                this.peerConnection["setConfiguration"]({iceServers: [turnServer]});
-            }));
-        }
+        // update turn servers when they change (see TurnServerSource)
+        this.disposables.track(this.options.turnServer.subscribe(turnServer => {
+            this.logItem.log({l: "updating turn server", turnServer})
+            this.peerConnection.setConfiguration({iceServers: [turnServer]});
+        }));
         const listen = <K extends keyof PeerConnectionEventMap>(type: K, listener: (this: PeerConnection, ev: PeerConnectionEventMap[K]) => any, options?: boolean | EventListenerOptions): void => {
             this.peerConnection.addEventListener(type, listener);
             const dispose = () => {

--- a/src/matrix/calls/TurnServerSource.ts
+++ b/src/matrix/calls/TurnServerSource.ts
@@ -24,7 +24,7 @@ import type {Clock, Timeout} from "../../platform/web/dom/Clock";
 import type {ILogItem} from "../../logging/types";
 
 type TurnServerSettings = {
-    urls: string[],
+    uris: string[],
     username: string,
     password: string,
     ttl: number
@@ -54,6 +54,7 @@ export class TurnServerSource {
             if (!this.isPolling) {
                 const settings = await this.doRequest(log);
                 const iceServer = settings ? toIceServer(settings) : this.defaultSettings;
+                log.set("iceServer", iceServer);
                 if (this.currentObservable) {
                     this.currentObservable.set(iceServer);
                 } else {
@@ -149,7 +150,7 @@ function shouldUpdate(observable: BaseObservableValue<RTCIceServer | undefined>,
 
 function toIceServer(settings: TurnServerSettings): RTCIceServer {
     return {
-        urls: settings.urls,
+        urls: settings.uris,
         username: settings.username,
         credential: settings.password,
         credentialType: "password"

--- a/src/matrix/calls/TurnServerSource.ts
+++ b/src/matrix/calls/TurnServerSource.ts
@@ -1,0 +1,222 @@
+/*
+Copyright 2022 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {RetainedObservableValue} from "../../observable/value/RetainedObservableValue";
+
+import type {HomeServerApi} from "../net/HomeServerApi";
+import type {IHomeServerRequest} from "../net/HomeServerRequest";
+import type {BaseObservableValue} from "../../observable/value/BaseObservableValue";
+import type {ObservableValue} from "../../observable/value/ObservableValue";
+import type {Clock, Timeout} from "../../platform/web/dom/Clock";
+import type {ILogItem} from "../../logging/types";
+
+type TurnServerSettings = {
+    urls: string[],
+    username: string,
+    password: string,
+    ttl: number
+};
+
+const DEFAULT_TTL = 5 * 60; // 5min
+const DEFAULT_SETTINGS: RTCIceServer = {
+    urls: ["stun:turn.matrix.org"],
+    username: "",
+    credential: "",
+};
+
+export class TurnServerSource {
+    private currentObservable?: ObservableValue<RTCIceServer>;
+    private pollTimeout?: Timeout;
+    private pollRequest?: IHomeServerRequest;
+    private isPolling = false;
+
+    constructor(
+        private hsApi: HomeServerApi,
+        private clock: Clock,
+        private defaultSettings: RTCIceServer = DEFAULT_SETTINGS
+    ) {}
+
+    getSettings(log: ILogItem): Promise<BaseObservableValue<RTCIceServer>> {
+        return log.wrap("get turn server", async log => {
+            if (!this.isPolling) {
+                const settings = await this.doRequest(log);
+                const iceServer = settings ? toIceServer(settings) : this.defaultSettings;
+                if (this.currentObservable) {
+                    this.currentObservable.set(iceServer);
+                } else {
+                    this.currentObservable = new RetainedObservableValue(iceServer, 
+                        () => {
+                            this.stopPollLoop();
+                        },
+                        () => {
+                            // start loop on first subscribe
+                            this.runLoop(this.currentObservable!, settings?.ttl ?? DEFAULT_TTL);
+                        });
+                }
+            }
+            return this.currentObservable!;
+        });
+    }
+
+    private async runLoop(observable: ObservableValue<RTCIceServer>, initialTtl: number): Promise<void> {
+        let ttl = initialTtl;
+        this.isPolling = true;
+        while(this.isPolling) {
+            try {
+                this.pollTimeout = this.clock.createTimeout(ttl * 1000);
+                await this.pollTimeout.elapsed();
+                this.pollTimeout = undefined;
+                const settings = await this.doRequest(undefined);
+                if (settings) {
+                    const iceServer = toIceServer(settings);
+                    if (shouldUpdate(observable, iceServer)) {
+                        observable.set(iceServer);
+                    }
+                    if (settings.ttl > 0) {
+                        ttl = settings.ttl;
+                    } else {
+                        // stop polling is settings are good indefinitely
+                        this.stopPollLoop();
+                    }
+                } else {
+                    ttl = DEFAULT_TTL;
+                }
+            } catch (err) {
+                if (err.name === "AbortError") {
+                    /* ignore, the loop will exit because isPolling is false */
+                } else {
+                    // TODO: log error
+                }
+            }
+        }
+    }
+
+    private async doRequest(log: ILogItem | undefined): Promise<TurnServerSettings | undefined> {
+        try {
+            this.pollRequest = this.hsApi.getTurnServer({log});
+            const settings = await this.pollRequest.response();
+            return settings;
+        } catch (err) {
+            if (err.name === "HomeServerError") {
+                return undefined;
+            }
+            throw err;
+        } finally {
+            this.pollRequest = undefined;
+        }
+    }
+
+    stopPollLoop() {
+        this.isPolling = false;
+        this.currentObservable = undefined;
+        this.pollTimeout?.dispose();
+        this.pollTimeout = undefined;
+        this.pollRequest?.abort();
+        this.pollRequest = undefined;
+    }
+
+    dispose() {
+        this.stopPollLoop();
+    }
+}
+
+function shouldUpdate(observable: BaseObservableValue<RTCIceServer | undefined>, settings: RTCIceServer): boolean {
+    const currentSettings = observable.get();
+    if (!currentSettings) {
+        return true;
+    }
+    // same length and new settings doesn't contain any uri the old settings don't contain
+    const currentUrls = Array.isArray(currentSettings.urls) ? currentSettings.urls : [currentSettings.urls];
+    const newUrls = Array.isArray(settings.urls) ? settings.urls : [settings.urls];
+    const arraysEqual = currentUrls.length === newUrls.length &&
+        !newUrls.some(uri => !currentUrls.includes(uri));
+    return !arraysEqual || settings.username !== currentSettings.username ||
+        settings.credential !== currentSettings.credential;
+}
+
+function toIceServer(settings: TurnServerSettings): RTCIceServer {
+    return {
+        urls: settings.urls,
+        username: settings.username,
+        credential: settings.password,
+        credentialType: "password"
+    }
+}
+
+export function tests() {
+    return {
+        "shouldUpdate returns false for same object": assert => {
+            const observable = {get() {
+                return {
+                    urls: ["a", "b"],
+                    username: "alice",
+                    credential: "f00",
+                };
+            }};
+            const same = {
+                urls: ["a", "b"],
+                username: "alice",
+                credential: "f00",
+            };
+            assert.equal(false, shouldUpdate(observable as any as BaseObservableValue<RTCIceServer>, same));
+        },
+        "shouldUpdate returns true for 1 different uri": assert => {
+            const observable = {get() {
+                return {
+                    urls: ["a", "c"],
+                    username: "alice",
+                    credential: "f00",
+                };
+            }};
+            const same = {
+                urls: ["a", "b"],
+                username: "alice",
+                credential: "f00",
+            };
+            assert.equal(true, shouldUpdate(observable as any as BaseObservableValue<RTCIceServer>, same));
+        },
+        "shouldUpdate returns true for different user": assert => {
+            const observable = {get() {
+                return {
+                    urls: ["a", "b"],
+                    username: "alice",
+                    credential: "f00",
+                };
+            }};
+            const same = {
+                urls: ["a", "b"],
+                username: "bob",
+                credential: "f00",
+            };
+            assert.equal(true, shouldUpdate(observable as any as BaseObservableValue<RTCIceServer>, same));
+        },
+        "shouldUpdate returns true for different password": assert => {
+            const observable = {get() {
+                return {
+                    urls: ["a", "b"],
+                    username: "alice",
+                    credential: "f00",
+                };
+            }};
+            const same = {
+                urls: ["a", "b"],
+                username: "alice",
+                credential: "b4r",
+            };
+            assert.equal(true, shouldUpdate(observable as any as BaseObservableValue<RTCIceServer>, same));
+        }
+    }
+}

--- a/src/matrix/calls/TurnServerSource.ts
+++ b/src/matrix/calls/TurnServerSource.ts
@@ -120,7 +120,7 @@ export class TurnServerSource {
         }
     }
 
-    stopPollLoop() {
+    private stopPollLoop() {
         this.isPolling = false;
         this.currentObservable = undefined;
         this.pollTimeout?.dispose();

--- a/src/matrix/calls/TurnServerSource.ts
+++ b/src/matrix/calls/TurnServerSource.ts
@@ -64,7 +64,7 @@ export class TurnServerSource {
                         },
                         () => {
                             // start loop on first subscribe
-                            this.runLoop(this.currentObservable!, settings?.ttl ?? DEFAULT_TTL);
+                            this.runLoop(settings?.ttl ?? DEFAULT_TTL);
                         });
                 }
             }
@@ -72,7 +72,7 @@ export class TurnServerSource {
         });
     }
 
-    private async runLoop(observable: ObservableValue<RTCIceServer>, initialTtl: number): Promise<void> {
+    private async runLoop(initialTtl: number): Promise<void> {
         let ttl = initialTtl;
         this.isPolling = true;
         while(this.isPolling) {
@@ -83,8 +83,8 @@ export class TurnServerSource {
                 const settings = await this.doRequest(undefined);
                 if (settings) {
                     const iceServer = toIceServer(settings);
-                    if (shouldUpdate(observable, iceServer)) {
-                        observable.set(iceServer);
+                    if (shouldUpdate(this.currentObservable!, iceServer)) {
+                        this.currentObservable!.set(iceServer);
                     }
                     if (settings.ttl > 0) {
                         ttl = settings.ttl;

--- a/src/matrix/calls/group/Member.ts
+++ b/src/matrix/calls/group/Member.ts
@@ -19,6 +19,7 @@ import {makeTxnId, makeId} from "../../common";
 import {EventType, CallErrorCode} from "../callEventTypes";
 import {formatToDeviceMessagesPayload} from "../../common";
 import {sortedIndex} from "../../../utils/sortedIndex";
+
 import type {MuteSettings} from "../common";
 import type {Options as PeerCallOptions, RemoteMedia} from "../PeerCall";
 import type {LocalMedia} from "../LocalMedia";
@@ -28,8 +29,9 @@ import type {GroupCall} from "./GroupCall";
 import type {RoomMember} from "../../room/members/RoomMember";
 import type {EncryptedMessage} from "../../e2ee/olm/Encryption";
 import type {ILogItem} from "../../../logging/types";
+import type {BaseObservableValue} from "../../../observable/value/BaseObservableValue";
 
-export type Options = Omit<PeerCallOptions, "emitUpdate" | "sendSignallingMessage"> & {
+export type Options = Omit<PeerCallOptions, "emitUpdate" | "sendSignallingMessage" | "turnServer"> & {
     confId: string,
     ownUserId: string,
     ownDeviceId: string,
@@ -60,6 +62,7 @@ class MemberConnection {
     constructor(
         public localMedia: LocalMedia,
         public localMuteSettings: MuteSettings,
+        public turnServer: BaseObservableValue<RTCIceServer>,
         public readonly logItem: ILogItem
     ) {}
 }
@@ -112,12 +115,17 @@ export class Member {
     }
 
     /** @internal */
-    connect(localMedia: LocalMedia, localMuteSettings: MuteSettings, memberLogItem: ILogItem): ILogItem | undefined {
+    connect(localMedia: LocalMedia, localMuteSettings: MuteSettings, turnServer: BaseObservableValue<RTCIceServer>, memberLogItem: ILogItem): ILogItem | undefined {
         if (this.connection) {
             return;
         }
         // Safari can't send a MediaStream to multiple sources, so clone it
-        const connection = new MemberConnection(localMedia.clone(), localMuteSettings, memberLogItem);
+        const connection = new MemberConnection(
+            localMedia.clone(),
+            localMuteSettings,
+            turnServer,
+            memberLogItem
+        );
         this.connection = connection;
         let connectLogItem;
         connection.logItem.wrap("connect", async log => {
@@ -204,7 +212,7 @@ export class Member {
             if (hangupReason && !errorCodesWithoutRetry.includes(hangupReason)) {
                 connection.retryCount += 1;
                 const {retryCount} = connection;
-                connection.logItem.wrap({l: "retry connection", retryCount}, async retryLog => {
+            connection.logItem.wrap({l: "retry connection", retryCount}, async retryLog => {
                     log.refDetached(retryLog);
                     if (retryCount <= 3) {
                         await this.callIfNeeded(retryLog);
@@ -337,9 +345,11 @@ export class Member {
     }
 
     private _createPeerCall(callId: string): PeerCall {
+        const connection = this.connection!;
         return new PeerCall(callId, Object.assign({}, this.options, {
             emitUpdate: this.emitUpdateFromPeerCall,
-            sendSignallingMessage: this.sendSignallingMessage
-        }), this.connection!.logItem);
+            sendSignallingMessage: this.sendSignallingMessage,
+            turnServer: connection.turnServer
+        }), connection.logItem);
     }
 }

--- a/src/matrix/calls/group/Member.ts
+++ b/src/matrix/calls/group/Member.ts
@@ -212,7 +212,7 @@ export class Member {
             if (hangupReason && !errorCodesWithoutRetry.includes(hangupReason)) {
                 connection.retryCount += 1;
                 const {retryCount} = connection;
-            connection.logItem.wrap({l: "retry connection", retryCount}, async retryLog => {
+                connection.logItem.wrap({l: "retry connection", retryCount}, async retryLog => {
                     log.refDetached(retryLog);
                     if (retryCount <= 3) {
                         await this.callIfNeeded(retryLog);

--- a/src/matrix/net/HomeServerApi.ts
+++ b/src/matrix/net/HomeServerApi.ts
@@ -305,9 +305,13 @@ export class HomeServerApi {
     createRoom(payload: Record<string, any>, options?: BaseRequestOptions): IHomeServerRequest {
         return this._post(`/createRoom`, {}, payload, options);
     }
-    
+
     setAccountData(ownUserId: string, type: string, content: Record<string, any>, options?: BaseRequestOptions): IHomeServerRequest {
         return this._put(`/user/${encodeURIComponent(ownUserId)}/account_data/${encodeURIComponent(type)}`, {}, content, options);
+    }
+
+    getTurnServer(options?: BaseRequestOptions): IHomeServerRequest {
+        return this._get(`/voip/turnServer`, undefined, undefined, options);
     }
 }
 

--- a/src/observable/value/RetainedObservableValue.ts
+++ b/src/observable/value/RetainedObservableValue.ts
@@ -17,15 +17,17 @@ limitations under the License.
 import {ObservableValue} from "./ObservableValue";
 
 export class RetainedObservableValue<T> extends ObservableValue<T> {
-    private _freeCallback: () => void;
 
-    constructor(initialValue: T, freeCallback: () => void) {
+    constructor(initialValue: T, private freeCallback: () => void, private startCallback: () => void = () => {}) {
         super(initialValue);
-        this._freeCallback = freeCallback;
+    }
+
+    onSubscribeFirst() {
+        this.startCallback();
     }
 
     onUnsubscribeLast() {
         super.onUnsubscribeLast();
-        this._freeCallback();
+        this.freeCallback();
     }
 }

--- a/src/platform/types/WebRTC.ts
+++ b/src/platform/types/WebRTC.ts
@@ -148,6 +148,7 @@ export interface PeerConnection {
     addEventListener<K extends keyof PeerConnectionEventMap>(type: K, listener: (this: PeerConnection, ev: PeerConnectionEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof PeerConnectionEventMap>(type: K, listener: (this: PeerConnection, ev: PeerConnectionEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
     getStats(selector?: Track | null): Promise<StatsReport>;
+    setConfiguration(configuration?: RTCConfiguration): void;
 }
 
 


### PR DESCRIPTION
Call the /voip/turnServer API every TTL seconds to ensure our calls use the right TURN server, rather than the hardcoded default stun:turn.matrix.org.  Otherwise we will never be able to set up relay candidates, and never be able to traverse firewalls reliably.