### PR TITLE
Fix sync error

### DIFF
--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -128,7 +128,7 @@ export class RoomViewModel extends ViewModel {
     // so emit all fields originating from summary
     _onRoomChange() {
         // propagate the update to the child view models so it's bindings can update based on room changes
-        this._composerVM.emitChange();
+        this._composerVM?.emitChange();
         this.emitChange();
     }
 


### PR DESCRIPTION
Fixes #866 

For a non-archived room, the composer vm is created via an async method (`async _recreateComposerOnPowerLevelChange()`) that is called from the ctor. It is possible that a room change event occurs before this async method finishes which would call `emitChange` on a composer that is yet to be created.