### PR TITLE
fix sdk build failing on tsc error

### DIFF
--- a/src/observable/map/BaseObservableMap.ts
+++ b/src/observable/map/BaseObservableMap.ts
@@ -64,8 +64,8 @@ export abstract class BaseObservableMap<K, V> extends BaseObservable<IMapObserve
         }
     }
 
-    join(...otherMaps: Array<typeof this>): JoinedMap<K, V> {
-        return new JoinedMap([this].concat(otherMaps));
+    join<E extends BaseObservableMap<K, V>>(...otherMaps: Array<E>): JoinedMap<K, V> {
+        return new JoinedMap([this as BaseObservableMap<K, V>].concat(otherMaps));
      }
 
      mapValues<MappedV>(mapper: Mapper<V, MappedV>, updater?: Updater<V, MappedV>): MappedMap<K, V, MappedV> {


### PR DESCRIPTION
SDK build is failing with this error:
```
src/observable/map/BaseObservableMap.ts:67:37 - error TS4073: Parameter 'otherMaps' of public method from exported class has or is using private name 'this'.

67     join(...otherMaps: Array<typeof this>): JoinedMap<K, V> {
                                       ~~~~


Found 1 error in src/observable/map/BaseObservableMap.ts:67

