### PR TITLE
Fix isMemberExpired check and typechecking

### DIFF
--- a/src/logging/NullLogger.ts
+++ b/src/logging/NullLogger.ts
@@ -21,7 +21,9 @@ function noop (): void {}
 export class NullLogger implements ILogger {
     public readonly item: ILogItem = new NullLogItem(this);
 
-    log(): void {}
+    log(): ILogItem {
+        return this.item;
+    }
 
     addReporter() {}
 

--- a/src/matrix/calls/group/Member.ts
+++ b/src/matrix/calls/group/Member.ts
@@ -416,5 +416,5 @@ export function memberExpiresAt(callDeviceMembership: CallDeviceMembership): num
 
 export function isMemberExpired(callDeviceMembership: CallDeviceMembership, now: number, margin: number = 0) {
     const expiresAt = memberExpiresAt(callDeviceMembership);
-    return typeof expiresAt === "number" && ((expiresAt + margin) <= now);
+    return typeof expiresAt === "number" ? ((expiresAt + margin) <= now) : true;
 }

--- a/src/platform/web/ui/session/room/CallView.ts
+++ b/src/platform/web/ui/session/room/CallView.ts
@@ -80,7 +80,7 @@ export class CallView extends TemplateView<CallViewModel> {
 
     public unmount() {
         if (this.resizeObserver) {
-            this.resizeObserver.unobserve((this.root()! as Element).querySelector(".CallView_members"));
+            this.resizeObserver.unobserve((this.root()! as Element).querySelector(".CallView_members")!);
             this.resizeObserver = undefined;
         }
         super.unmount();


### PR DESCRIPTION
If the expires at key is undefined the member should be ignored / disconnected. Also fixed some typechecking errors that happen on `yarn build:sdk`