### PR TITLE
Encode SSO redirect URL as it may contain multiple query parameters

### DIFF
--- a/src/matrix/login/SSOLoginHelper.ts
+++ b/src/matrix/login/SSOLoginHelper.ts
@@ -24,6 +24,6 @@ export class SSOLoginHelper{
     get homeserver(): string { return this._homeserver; }
 
     createSSORedirectURL(returnURL: string): string {
-        return `${this._homeserver}/_matrix/client/r0/login/sso/redirect?redirectUrl=${returnURL}`;
+        return `${this._homeserver}/_matrix/client/r0/login/sso/redirect?redirectUrl=${encodeURIComponent(returnURL)}`;
     }
 }


### PR DESCRIPTION
If the `returnURL` contains multiple query parameters (e.g. http://localhost:3000?foo=bar&bar=baz), the homeserver would fail to correctly parse the URL, and only the first query parameter would be kept.

This is not an issue with the homeserver since the URL cannot be parsed in an unambiguous way, as the resulting URL would be:

https://example.com/_matrix/client/r0/login/sso/redirect?redirectUrl=http://localhost:3000?foo=bar&bar=baz

It's not possible to know whether the bar parameter is part of the "parent" URL, or part of the `redirectUrl` parameter.

----

To fix this, we now encode the `redirectUrl` parameter, which results in:

https://example.com/_matrix/client/r0/login/sso/redirect?redirectUrl=http%3A%2F%2Flocalhost%3A3000%3Ffoo%3Dbar%26bar%3Dbaz

This URL is correctly parsed by synapse.