### PR TITLE
Add a way to toggle `scrollToBottom` so you can start scroll from the top as well and continue reading

### DIFF
--- a/doc/SDK.md
+++ b/doc/SDK.md
@@ -89,7 +89,7 @@ async function main() {
             navigation,
         });
         await vm.load();
-        const view = new TimelineView(vm.timelineViewModel, viewClassForTile);
+        const view = new TimelineView(vm.timelineViewModel, { viewClassForTile });
         app.appendChild(view.mount());
     }
 }

--- a/src/platform/web/ui/session/room/RoomView.js
+++ b/src/platform/web/ui/session/room/RoomView.js
@@ -55,7 +55,7 @@ export class RoomView extends TemplateView {
                 )]),
                 t.mapView(vm => vm.timelineViewModel, timelineViewModel => {
                     return timelineViewModel ?
-                        new TimelineView(timelineViewModel, this._viewClassForTile) :
+                        new TimelineView(timelineViewModel, { viewClassForTile: this._viewClassForTile }) :
                         new TimelineLoadingView(vm);    // vm is just needed for i18n
                 }),
                 t.mapView(vm => vm.composerViewModel,

--- a/src/platform/web/ui/session/room/TimelineView.ts
+++ b/src/platform/web/ui/session/room/TimelineView.ts
@@ -57,6 +57,10 @@ function findFirstNodeIndexAtOrBelow(tiles: HTMLElement, top: number, startIndex
     return 0;
 }
 
+interface TimelineViewOpts {
+    viewClassForTile: ViewClassForEntryFn
+    stickToBottom: boolean
+}
 export class TimelineView extends TemplateView<TimelineViewModel> {
 
     private anchoredNode?: HTMLElement;
@@ -64,9 +68,16 @@ export class TimelineView extends TemplateView<TimelineViewModel> {
     private stickToBottom: boolean = true;
     private tilesView?: TilesListView;
     private resizeObserver?: ResizeObserver;
+    private viewClassForTile: ViewClassForEntryFn;
 
-    constructor(vm: TimelineViewModel, private readonly viewClassForTile: ViewClassForEntryFn) {
+    constructor(vm: TimelineViewModel, {
+        viewClassForTile,
+        stickToBottom = true
+    }: TimelineViewOpts) {
         super(vm);
+
+        this.viewClassForTile = viewClassForTile;
+        this.stickToBottom = stickToBottom;
     }
 
     render(t: Builder<TimelineViewModel>, vm: TimelineViewModel) {


### PR DESCRIPTION
Add a way to toggle `scrollToBottom` so you can start scroll from the top as well and continue reading.

Split out from https://github.com/vector-im/hydrogen-web/pull/653

See `?continue=top` in https://github.com/matrix-org/matrix-public-archive/pull/114 for how this is specifically used. When jumping to the next page of activity, you want to start from the top to continue reading where you left off.

### Future notes

For Matrix Public Archive we want:

 - Scrolled to bottom (normal or when jumping to previous page of activity)
 - Scrolled to top (when jumping to next page of activity), https://github.com/matrix-org/matrix-public-archive/pull/114
 - Event highlighted and focused in the middle, https://github.com/matrix-org/matrix-public-archive/issues/4
 - Event with date header scroll aligned with top of viewport, https://github.com/matrix-org/matrix-public-archive/issues/73

 
 ### Potential alternatives

Add a way to disable all scroll controls from Hydrogen itself and have the downstream API consumer control everything.

I could see Hydrogen supporting most of those scroll behaviors though (except scrolled to top).