### PR TITLE
Add full MXID tooltip to message avatar

### DIFF
--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -75,7 +75,7 @@ export class BaseMessageTile extends SimpleTile {
     }
 
     get avatarTitle() {
-        return this.displayName;
+        return this.sender;
     }
 
     get date() {

--- a/src/platform/web/ui/avatar.js
+++ b/src/platform/web/ui/avatar.js
@@ -31,7 +31,11 @@ export function renderStaticAvatar(vm, size, extraClasses = undefined) {
         avatarClasses += ` ${extraClasses}`;
     }
     const avatarContent = hasAvatar ? renderImg(vm, size) : text(vm.avatarLetter);
-    const avatar = tag.div({className: avatarClasses, "data-testid": "avatar"}, [avatarContent]);
+    const avatar = tag.div({
+        className: avatarClasses,
+        title: vm.avatarTitle,
+        "data-testid": "avatar",
+    }, [avatarContent]);
     if (hasAvatar) {
         setAttribute(avatar, "data-avatar-letter", vm.avatarLetter);
         setAttribute(avatar, "data-avatar-color", vm.avatarColorNumber);


### PR DESCRIPTION
Add full MXID tooltip to message avatar to be able to disambiguate users without opening the member in the right-panel

![](https://user-images.githubusercontent.com/558581/200737241-3a9815e5-e52a-4ac3-befc-3806e06e908e.png)
