### PR TITLE
Rename `urlRouter` usage to `urlRouter` instead of `urlCreator`

### DIFF
--- a/doc/SDK.md
+++ b/doc/SDK.md
@@ -85,7 +85,7 @@ async function main() {
             room,
             ownUserId: session.userId,
             platform,
-            urlCreator: urlRouter,
+            urlRouter: urlRouter,
             navigation,
         });
         await vm.load();

--- a/doc/impl-thoughts/SSO.md
+++ b/doc/impl-thoughts/SSO.md
@@ -30,7 +30,7 @@ if (loginOptions.sso) {
     // store the homeserver for when we get redirected back after the sso flow
     platform.settingsStorage.setString("sso_homeserver", loginOptions.homeserver);
     // create the redirect url
-    const callbackUrl = urlCreator.createSSOCallbackURL(); // will just return the document url without any fragment
+    const callbackUrl = urlRouter.createSSOCallbackURL(); // will just return the document url without any fragment
     const redirectUrl = sso.createRedirectUrl(callbackUrl, provider);
     // and open it
     platform.openURL(redirectUrl);

--- a/src/domain/LogoutViewModel.ts
+++ b/src/domain/LogoutViewModel.ts
@@ -43,7 +43,7 @@ export class LogoutViewModel extends ViewModel<SegmentType, Options> {
     }
 
     get cancelUrl(): string | undefined {
-        return this.urlCreator.urlForSegment("session", true);
+        return this.urlRouter.urlForSegment("session", true);
     }
 
     async logout(): Promise<void> {

--- a/src/domain/RootViewModel.js
+++ b/src/domain/RootViewModel.js
@@ -83,14 +83,14 @@ export class RootViewModel extends ViewModel {
                 }
             }
         } else if (loginToken) {
-            this.urlCreator.normalizeUrl();
+            this.urlRouter.normalizeUrl();
             if (this.activeSection !== "login") {
                 this._showLogin(loginToken);
             }
         }
         else {
             try {
-                if (!(shouldRestoreLastUrl && this.urlCreator.tryRestoreLastUrl())) {
+                if (!(shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl())) {
                     const sessionInfos = await this.platform.sessionInfoStorage.getAll();
                     if (sessionInfos.length === 0) {
                         this.navigation.push("login");

--- a/src/domain/SessionLoadViewModel.js
+++ b/src/domain/SessionLoadViewModel.js
@@ -29,7 +29,7 @@ export class SessionLoadViewModel extends ViewModel {
         this._deleteSessionOnCancel = deleteSessionOnCancel;
         this._loading = false;
         this._error = null;
-        this.backUrl = this.urlCreator.urlForSegment("session", true);
+        this.backUrl = this.urlRouter.urlForSegment("session", true);
         this._accountSetupViewModel = undefined;
 
     }

--- a/src/domain/SessionPickerViewModel.js
+++ b/src/domain/SessionPickerViewModel.js
@@ -38,7 +38,7 @@ class SessionItemViewModel extends ViewModel {
     }
 
     get openUrl() {
-        return this.urlCreator.urlForSegment("session", this.id);
+        return this.urlRouter.urlForSegment("session", this.id);
     }
 
     get label() {
@@ -94,6 +94,6 @@ export class SessionPickerViewModel extends ViewModel {
     }
 
     get cancelUrl() {
-        return this.urlCreator.urlForSegment("login");
+        return this.urlRouter.urlForSegment("login");
     }
 }

--- a/src/domain/ViewModel.ts
+++ b/src/domain/ViewModel.ts
@@ -33,7 +33,7 @@ import type {IURLRouter} from "./navigation/URLRouter";
 export type Options<T extends object = SegmentType> = {
     platform: Platform;
     logger: ILogger;
-    urlCreator: IURLRouter<T>;
+    urlRouter: IURLRouter<T>;
     navigation: Navigation<T>;
     emitChange?: (params: any) => void;
 }
@@ -137,8 +137,8 @@ export class ViewModel<N extends object = SegmentType, O extends Options<N> = Op
         return this.platform.logger;
     }
 
-    get urlCreator(): IURLRouter<N> {
-        return this._options.urlCreator;
+    get urlRouter(): IURLRouter<N> {
+        return this._options.urlRouter;
     }
 
     get navigation(): Navigation<N> {

--- a/src/domain/login/StartSSOLoginViewModel.ts
+++ b/src/domain/login/StartSSOLoginViewModel.ts
@@ -42,7 +42,7 @@ export class StartSSOLoginViewModel extends ViewModel{
 
     async startSSOLogin(): Promise<void> {
         await this.platform.settingsStorage.setString("sso_ongoing_login_homeserver", this._sso!.homeserver);
-        const link = this._sso!.createSSORedirectURL(this.urlCreator.createSSOCallbackURL());
+        const link = this._sso!.createSSORedirectURL(this.urlRouter.createSSOCallbackURL());
         this.platform.openUrl(link);
     }
 }

--- a/src/domain/session/SessionStatusViewModel.js
+++ b/src/domain/session/SessionStatusViewModel.js
@@ -36,7 +36,7 @@ export class SessionStatusViewModel extends ViewModel {
         this._reconnector = reconnector;
         this._status = this._calculateState(reconnector.connectionStatus.get(), sync.status.get());
         this._session = session;
-        this._setupKeyBackupUrl = this.urlCreator.urlForSegment("settings");
+        this._setupKeyBackupUrl = this.urlRouter.urlForSegment("settings");
         this._dismissSecretStorage = false;
     }
 

--- a/src/domain/session/leftpanel/InviteTileViewModel.js
+++ b/src/domain/session/leftpanel/InviteTileViewModel.js
@@ -22,7 +22,7 @@ export class InviteTileViewModel extends BaseTileViewModel {
         super(options);
         const {invite} = options;
         this._invite = invite;
-        this._url = this.urlCreator.openRoomActionUrl(this._invite.id);
+        this._url = this.urlRouter.openRoomActionUrl(this._invite.id);
     }
 
     get busy() { return this._invite.accepting || this._invite.rejecting; }
@@ -53,9 +53,9 @@ export class InviteTileViewModel extends BaseTileViewModel {
 export function tests() {
     return {
         "test compare with timestamp": assert => {
-            const urlCreator = {openRoomActionUrl() { return "";}}
-            const vm1 = new InviteTileViewModel({invite: {timestamp: 500, id: "1"}, urlCreator});
-            const vm2 = new InviteTileViewModel({invite: {timestamp: 250, id: "2"}, urlCreator});
+            const urlRouter = {openRoomActionUrl() { return "";}}
+            const vm1 = new InviteTileViewModel({invite: {timestamp: 500, id: "1"}, urlRouter});
+            const vm2 = new InviteTileViewModel({invite: {timestamp: 250, id: "2"}, urlRouter});
             assert(vm1.compare(vm2) < 0);
             assert(vm2.compare(vm1) > 0);
             assert.equal(vm1.compare(vm1), 0);

--- a/src/domain/session/leftpanel/LeftPanelViewModel.js
+++ b/src/domain/session/leftpanel/LeftPanelViewModel.js
@@ -32,8 +32,8 @@ export class LeftPanelViewModel extends ViewModel {
         this._tileViewModels = this._tileViewModelsFilterMap.sortValues((a, b) => a.compare(b));
         this._currentTileVM = null;
         this._setupNavigation();
-        this._closeUrl = this.urlCreator.urlForSegment("session");
-        this._settingsUrl = this.urlCreator.urlForSegment("settings");
+        this._closeUrl = this.urlRouter.urlForSegment("session");
+        this._settingsUrl = this.urlRouter.urlForSegment("settings");
     }
 
     _mapTileViewModels(roomsBeingCreated, invites, rooms) {

--- a/src/domain/session/leftpanel/RoomBeingCreatedTileViewModel.js
+++ b/src/domain/session/leftpanel/RoomBeingCreatedTileViewModel.js
@@ -23,7 +23,7 @@ export class RoomBeingCreatedTileViewModel extends BaseTileViewModel {
         super(options);
         const {roomBeingCreated} = options;
         this._roomBeingCreated = roomBeingCreated;
-        this._url = this.urlCreator.openRoomActionUrl(this._roomBeingCreated.id);
+        this._url = this.urlRouter.openRoomActionUrl(this._roomBeingCreated.id);
     }
 
     get busy() { return !this._roomBeingCreated.error; }
@@ -59,9 +59,9 @@ export class RoomBeingCreatedTileViewModel extends BaseTileViewModel {
 export function tests() {
     return {
         "test compare with names": assert => {
-            const urlCreator = {openRoomActionUrl() { return "";}}
-            const vm1 = new RoomBeingCreatedTileViewModel({roomBeingCreated: {name: "A", id: "1"}, urlCreator});
-            const vm2 = new RoomBeingCreatedTileViewModel({roomBeingCreated: {name: "B", id: "2"}, urlCreator});
+            const urlRouter = {openRoomActionUrl() { return "";}}
+            const vm1 = new RoomBeingCreatedTileViewModel({roomBeingCreated: {name: "A", id: "1"}, urlRouter});
+            const vm2 = new RoomBeingCreatedTileViewModel({roomBeingCreated: {name: "B", id: "2"}, urlRouter});
             assert(vm1.compare(vm2) < 0);
             assert(vm2.compare(vm1) > 0);
             assert.equal(vm1.compare(vm1), 0);

--- a/src/domain/session/leftpanel/RoomTileViewModel.js
+++ b/src/domain/session/leftpanel/RoomTileViewModel.js
@@ -22,7 +22,7 @@ export class RoomTileViewModel extends BaseTileViewModel {
         super(options);
         const {room} = options;
         this._room = room;
-        this._url = this.urlCreator.openRoomActionUrl(this._room.id);
+        this._url = this.urlRouter.openRoomActionUrl(this._room.id);
     }
 
     get kind() {

--- a/src/domain/session/rightpanel/MemberTileViewModel.js
+++ b/src/domain/session/rightpanel/MemberTileViewModel.js
@@ -48,7 +48,7 @@ export class MemberTileViewModel extends ViewModel {
 
     get detailsUrl() {
         const roomId = this.navigation.path.get("room").value;
-        return `${this.urlCreator.openRoomActionUrl(roomId)}/member/${this._member.userId}`;
+        return `${this.urlRouter.openRoomActionUrl(roomId)}/member/${this._member.userId}`;
     }
 
     _updatePreviousName(newName) {

--- a/src/domain/session/rightpanel/RightPanelViewModel.js
+++ b/src/domain/session/rightpanel/RightPanelViewModel.js
@@ -64,8 +64,8 @@ export class RightPanelViewModel extends ViewModel {
         this._hookUpdaterToSegment("member", MemberDetailsViewModel, () => this._getMemberDetailsArguments(),
             () => {
                 // If we fail to create the member details panel, fallback to memberlist
-                const url = `${this.urlCreator.urlUntilSegment("room")}/members`;
-                this.urlCreator.pushUrl(url);
+                const url = `${this.urlRouter.urlUntilSegment("room")}/members`;
+                this.urlRouter.pushUrl(url);
             }
         );
     }

--- a/src/domain/session/room/InviteViewModel.js
+++ b/src/domain/session/room/InviteViewModel.js
@@ -26,7 +26,7 @@ export class InviteViewModel extends ViewModel {
         this._mediaRepository = mediaRepository;
         this._onInviteChange = this._onInviteChange.bind(this);
         this._error = null;
-        this._closeUrl = this.urlCreator.urlUntilSegment("session");
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
         this._invite.on("change", this._onInviteChange);
         this._inviter = null;
         if (this._invite.inviter) {

--- a/src/domain/session/room/LightboxViewModel.js
+++ b/src/domain/session/room/LightboxViewModel.js
@@ -22,8 +22,7 @@ export class LightboxViewModel extends ViewModel {
         this._eventId = options.eventId;
         this._unencryptedImageUrl = null;
         this._decryptedImage = null;
-        this._closeUrl = this.urlCreator.urlUntilSegment("room");
-        this._eventEntry = null;
+        this._closeUrl = this.urlRouter.urlUntilSegment("room");
         this._date = null;
         this._subscribeToEvent(options.room, options.eventId);
     }

--- a/src/domain/session/room/RoomBeingCreatedViewModel.js
+++ b/src/domain/session/room/RoomBeingCreatedViewModel.js
@@ -25,7 +25,7 @@ export class RoomBeingCreatedViewModel extends ViewModel {
         this._roomBeingCreated = roomBeingCreated;
         this._mediaRepository = mediaRepository;
         this._onRoomChange = this._onRoomChange.bind(this);
-        this._closeUrl = this.urlCreator.urlUntilSegment("session");
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
         this._roomBeingCreated.on("change", this._onRoomChange);
     }
 

--- a/src/domain/session/room/RoomViewModel.js
+++ b/src/domain/session/room/RoomViewModel.js
@@ -43,7 +43,7 @@ export class RoomViewModel extends ViewModel {
             this._recreateComposerOnPowerLevelChange();
         }
         this._clearUnreadTimout = null;
-        this._closeUrl = this.urlCreator.urlUntilSegment("session");
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
     }
 
     async load() {

--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -58,7 +58,7 @@ export class BaseMessageTile extends SimpleTile {
     }
 
     get memberPanelLink() {
-        return `${this.urlCreator.urlUntilSegment("room")}/member/${this.sender}`;
+        return `${this.urlRouter.urlUntilSegment("room")}/member/${this.sender}`;
     }
 
     // Avatar view model contract

--- a/src/domain/session/room/timeline/tiles/ImageTile.js
+++ b/src/domain/session/room/timeline/tiles/ImageTile.js
@@ -20,7 +20,7 @@ import {BaseMediaTile} from "./BaseMediaTile.js";
 export class ImageTile extends BaseMediaTile {
     constructor(entry, options) {
         super(entry, options);
-        this._lightboxUrl = this.urlCreator.urlForSegments([
+        this._lightboxUrl = this.urlRouter.urlForSegments([
             // ensure the right room is active if in grid view
             this.navigation.segment("room", this._room.id),
             this.navigation.segment("lightbox", this._entry.id)

--- a/src/domain/session/settings/SettingsViewModel.js
+++ b/src/domain/session/settings/SettingsViewModel.js
@@ -45,7 +45,7 @@ export class SettingsViewModel extends ViewModel {
         const {client} = options;
         this._client = client;
         this._keyBackupViewModel = this.track(new KeyBackupViewModel(this.childOptions({session: this._session})));
-        this._closeUrl = this.urlCreator.urlUntilSegment("session");
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
         this._estimate = null;
         this.sentImageSizeLimit = null;
         this.minSentImageSizeLimit = 400;

--- a/src/platform/web/main.js
+++ b/src/platform/web/main.js
@@ -41,7 +41,7 @@ export async function main(platform) {
             platform,
             // the only public interface of the router is to create urls,
             // so we call it that in the view models
-            urlCreator: urlRouter,
+            urlRouter: urlRouter,
             navigation,
         });
         await vm.load();


### PR DESCRIPTION
Rename `urlRouter` usage to `urlRouter` instead of `urlCreator`.

This is an initial step to https://github.com/vector-im/hydrogen-web/issues/677 where we probably want to introduce a separate `URLCreator` which will be its own thing.