### PR TITLE
Add full MXID tooltip to message sender display name

### DIFF
--- a/src/platform/web/ui/session/room/timeline/BaseMessageView.js
+++ b/src/platform/web/ui/session/room/timeline/BaseMessageView.js
@@ -63,7 +63,13 @@ export class BaseMessageView extends TemplateView {
                 li.removeChild(li.querySelector(".Timeline_messageSender"));
             } else if (!isContinuation && !this._isReplyPreview) {
                 const avatar = tag.a({href: vm.memberPanelLink, className: "Timeline_messageAvatar"}, [renderStaticAvatar(vm, 30)]);
-                const sender = tag.div({className: `Timeline_messageSender usercolor${vm.avatarColorNumber}`}, vm.displayName);
+                const sender = tag.div(
+                    {
+                        className: `Timeline_messageSender usercolor${vm.avatarColorNumber}`,
+                        title: vm.sender,
+                    },
+                    vm.displayName,
+                );
                 li.insertBefore(avatar, li.firstChild);
                 li.insertBefore(sender, li.firstChild);
             }


### PR DESCRIPTION
Add full MXID tooltip to message sender display name to disambiguate users without opening the member in the right-panel

Follow-up to https://github.com/vector-im/hydrogen-web/pull/917

![](https://user-images.githubusercontent.com/558581/201253757-7ba95a9f-ea5b-4570-9bb1-3a73996f26e3.png)
