### PR TITLE
Add `<dialog>`, `<details>`, and `<optgroup>` HTML elements to use with templating

### DIFF
--- a/src/platform/web/ui/general/html.ts
+++ b/src/platform/web/ui/general/html.ts
@@ -102,10 +102,10 @@ export const SVG_NS: string = "http://www.w3.org/2000/svg";
 export const TAG_NAMES = {
     [HTML_NS]: [
         "br", "a", "ol", "ul", "li", "div", "h1", "h2", "h3", "h4", "h5", "h6",
-        "p", "strong", "em", "span", "img", "section", "header", "main", "footer",
-        "article", "aside", "del", "blockquote",
+        "p", "strong", "em", "span", "img", "section", "header", "main", "footer", "dialog",
+        "article", "aside", "del", "blockquote", "details", "summary",
         "table", "thead", "tbody", "tr", "th", "td", "hr",
-        "pre", "code", "button", "time", "input", "textarea", "select", "option", "label", "form",
+        "pre", "code", "button", "time", "input", "textarea", "select", "option", "optgroup", "label", "form",
         "progress", "output", "video", "style"],
     [SVG_NS]: ["svg", "g", "path", "circle", "ellipse", "rect", "use"]
 } as const;


### PR DESCRIPTION
Add `<dialog>`, `<details>`, and `<optgroup>` HTML elements to use with templating

Split out from https://github.com/vector-im/hydrogen-web/pull/653