### PR TITLE
Draft: Added back buttons to join room related pages

### DIFF
--- a/src/domain/session/CreateRoomViewModel.js
+++ b/src/domain/session/CreateRoomViewModel.js
@@ -33,8 +33,10 @@ export class CreateRoomViewModel extends ViewModel {
         this._avatarScaledBlob = undefined;
         this._avatarFileName = undefined;
         this._avatarInfo = undefined;
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
     }
 
+    get closeUrl() { return this._closeUrl; }
     get isPublic() { return this._isPublic; }
     get isEncrypted() { return this._isEncrypted; }
     get canCreate() { return !!this._name; }

--- a/src/domain/session/JoinRoomViewModel.ts
+++ b/src/domain/session/JoinRoomViewModel.ts
@@ -27,10 +27,12 @@ export class JoinRoomViewModel extends ViewModel<SegmentType, Options> {
     private _session: Session;
     private _joinInProgress: boolean = false;
     private _error: Error | undefined;
+    private _closeUrl: string
 
     constructor(options: Readonly<Options>) {
         super(options);
         this._session = options.session;
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
     }
 
     async join(roomId: string): Promise<void> {
@@ -47,6 +49,8 @@ export class JoinRoomViewModel extends ViewModel<SegmentType, Options> {
             this.emitChange("error");
         }
     }
+
+    get closeUrl() { return this._closeUrl; }
 
     get joinInProgress(): boolean {
         return this._joinInProgress;

--- a/src/domain/session/room/UnknownRoomViewModel.js
+++ b/src/domain/session/room/UnknownRoomViewModel.js
@@ -24,7 +24,10 @@ export class UnknownRoomViewModel extends ViewModel {
         this.roomIdOrAlias = roomIdOrAlias;
         this._error = null;
         this._busy = false;
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
     }
+
+    get closeUrl() { return this._closeUrl; }
 
     get error() {
         return this._error?.message;

--- a/src/platform/web/ui/session/CreateRoomView.js
+++ b/src/platform/web/ui/session/CreateRoomView.js
@@ -23,7 +23,10 @@ export class CreateRoomView extends TemplateView {
     render(t, vm) {
         return t.main({className: "middle"}, 
             t.div({className: "CreateRoomView centered-column"}, [
-                t.h2("Create room"),
+                t.div({className: "middle-header"}, [
+                    t.a({className: "button-utility close-middle", href: vm.closeUrl, title: vm.i18n`Close room`}),
+                    t.h2("Create room"),
+                ]),
                 //t.div({className: "RoomView_error"}, vm => vm.error),
                 t.form({className: "CreateRoomView_detailsForm form", onChange: evt => this.onFormChange(evt), onSubmit: evt => this.onSubmit(evt)}, [
                     t.div({className: "vertical-layout"}, [

--- a/src/platform/web/ui/session/JoinRoomView.ts
+++ b/src/platform/web/ui/session/JoinRoomView.ts
@@ -29,7 +29,11 @@ export class JoinRoomView extends TemplateView<JoinRoomViewModel> {
         });
         return t.main({className: "middle"}, 
             t.div({className: "JoinRoomView centered-column"}, [
-                t.h2("Join room"),
+                t.div({className: "middle-header"}, [
+                    t.a({className: "button-utility close-middle", href: vm.closeUrl, title: vm.i18n`Close room`}),
+                    t.h2("Join room")
+
+                ]),
                 t.form({className: "JoinRoomView_detailsForm form", onSubmit: evt => this.onSubmit(evt,  input.value)}, [
                     t.div({className: "vertical-layout"}, [
                         t.div({className: "stretch form-row text"}, [

--- a/src/platform/web/ui/session/room/UnknownRoomView.js
+++ b/src/platform/web/ui/session/room/UnknownRoomView.js
@@ -19,6 +19,9 @@ import {TemplateView} from "../../general/TemplateView";
 export class UnknownRoomView extends TemplateView {
     render(t, vm) {
         return t.main({className: "UnknownRoomView middle"}, t.div([
+            t.div({className: "middle-header"}, [
+                t.a({className: "button-utility close-middle", href: vm.closeUrl, title: vm.i18n`Close room`}),
+            ]),
             t.h2([
                 vm.i18n`You are currently not in ${vm.roomIdOrAlias}.`,
                 t.br(),


### PR DESCRIPTION
This hot-fixes #936 #903 and #904

This is not pretty, I just wanted to restore usability for my users.
I would suggest solving this with some kind of inheritance so not every view/model has to do it on its own.
Also the styling is off in all 3 cases

Feel free to throw everything away or modify it.