### PR TITLE
restore active reaction bg color to be transparent version of accent color

### DIFF
--- a/doc/THEMING.md
+++ b/doc/THEMING.md
@@ -80,6 +80,7 @@ Currently supported operations are:
 | -------- | -------- | -------- |
 | darker     | percentage | color |
 | lighter     | percentage | color |
+| alpha     | alpha percentage | color |
 
 ## Aliases
 It is possible give aliases to variables in the `theme.css` file:

--- a/src/platform/web/theming/shared/color.mjs
+++ b/src/platform/web/theming/shared/color.mjs
@@ -36,5 +36,8 @@ export function derive(value, operation, argument, isDark) {
             const newColorString = offColor(value).lighten(argumentAsNumber / 100).hex();
             return newColorString;
         }
+        case "alpha": {
+            return offColor(value).rgba(argumentAsNumber / 100);
+        }
     }
 }

--- a/src/platform/web/ui/css/themes/element/timeline.css
+++ b/src/platform/web/ui/css/themes/element/timeline.css
@@ -364,7 +364,7 @@ only loads when the top comes into view*/
 }
 
 .Timeline_messageReactions button.active {
-    background-color: var(--background-color-secondary);
+    background-color: var(--accent-color--alpha-11);
     border-color: var(--accent-color);
 }
 


### PR DESCRIPTION
I thought there was an issue for this but can't find it :shrug: 

This adds support for the `alpha` color operation in the theming support.