### PR TITLE
Fix SSO query params

### DIFF
--- a/src/domain/navigation/URLRouter.ts
+++ b/src/domain/navigation/URLRouter.ts
@@ -153,8 +153,11 @@ export class URLRouter<T extends {session: string | boolean}> implements IURLRou
     }
 
     normalizeUrl(): void {
-        // Remove any queryParameters from the URL
-        // Gets rid of the loginToken after SSO
-        this._history.replaceUrlSilently(`${window.location.origin}/${window.location.hash}`);
+        const url = new URL(window.location.href);
+
+        // Remove the loginToken query parameter from the URL after SSO.
+        url.searchParams.delete("loginToken");
+
+        this._history.replaceUrlSilently(url.toString());
     }
 }

--- a/src/domain/navigation/URLRouter.ts
+++ b/src/domain/navigation/URLRouter.ts
@@ -149,7 +149,7 @@ export class URLRouter<T extends {session: string | boolean}> implements IURLRou
     }
 
     createSSOCallbackURL(): string {
-        return window.location.origin;
+        return window.location.href;
     }
 
     normalizeUrl(): void {


### PR DESCRIPTION
Currently, SSO is not functional when hydrogen is loaded on a page with a URL containing query parameters (e.g. `http://example.com?foo=bar&bar=baz`), as the query parameters get stripped.

The query parameters are removed in two places:

1. Query parameters are stripped from the `redirectUrl` parameter, so the resulting URL is `https://example.com/_matrix/client/r0/login/sso/redirect?redirectUrl=http://example.com`.
2. Query parameters are stripped upon returning to the page once SSO is done.

In #911 we made it so that SSO callback URLs containing query parameters are correctly passed to the homeserver. However, we weren't yet actually passing the query parameters, as described above. This PR fixes that, so that:

1. The `redirectUrl` parameter now contains query parameters, e.g. `https://example.com/_matrix/client/r0/login/sso/redirect?redirectUrl=http%3A%2F%2Fexample.com%3Afoo%3Dbar%26bar%3Dbaz`
2. Only the `loginToken` query parameter is stripped upon returning to the page after SSO.