### PR TITLE
Allow closing room creation and room joining views on small screens

### DIFF
--- a/src/domain/session/CreateRoomViewModel.js
+++ b/src/domain/session/CreateRoomViewModel.js
@@ -33,6 +33,7 @@ export class CreateRoomViewModel extends ViewModel {
         this._avatarScaledBlob = undefined;
         this._avatarFileName = undefined;
         this._avatarInfo = undefined;
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
     }
 
     get isPublic() { return this._isPublic; }
@@ -45,6 +46,7 @@ export class CreateRoomViewModel extends ViewModel {
     get hasAvatar() { return !!this._avatarScaledBlob; }
     get isFederationDisabled() { return this._isFederationDisabled; }
     get isAdvancedShown() { return this._isAdvancedShown; }
+    get closeUrl() { return this._closeUrl; }
 
     setName(name) {
         this._name = name;

--- a/src/domain/session/JoinRoomViewModel.ts
+++ b/src/domain/session/JoinRoomViewModel.ts
@@ -27,11 +27,15 @@ export class JoinRoomViewModel extends ViewModel<SegmentType, Options> {
     private _session: Session;
     private _joinInProgress: boolean = false;
     private _error: Error | undefined;
+    private _closeUrl: string;
 
     constructor(options: Readonly<Options>) {
         super(options);
         this._session = options.session;
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
     }
+
+    get closeUrl(): string { return this._closeUrl; }
 
     async join(roomId: string): Promise<void> {
         this._error = undefined;

--- a/src/domain/session/room/UnknownRoomViewModel.js
+++ b/src/domain/session/room/UnknownRoomViewModel.js
@@ -24,6 +24,11 @@ export class UnknownRoomViewModel extends ViewModel {
         this.roomIdOrAlias = roomIdOrAlias;
         this._error = null;
         this._busy = false;
+        this._closeUrl = this.urlRouter.urlUntilSegment("session");
+    }
+
+    get closeUrl() {
+        return this._closeUrl;
     }
 
     get error() {

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -1180,7 +1180,7 @@ button.RoomDetailsView_row::after {
     gap: 12px;
 }
 
-.CreateRoomView, .JoinRoomView, .RoomBeingCreated_error {
+.CreateRoomView_body, .JoinRoomView, .RoomBeingCreated_error {
     max-width: 400px;
 }
 

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -1180,7 +1180,7 @@ button.RoomDetailsView_row::after {
     gap: 12px;
 }
 
-.CreateRoomView_body, .JoinRoomView, .RoomBeingCreated_error {
+.CreateRoomView_body, .JoinRoomView_body, .RoomBeingCreated_error {
     max-width: 400px;
 }
 

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -959,9 +959,16 @@ button.link {
     margin: 0;
 }
 
-.UnknownRoomView_body {
+.UnknownRoomView_container {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+}
+
+.UnknownRoomView_body {
+    height: 100%;
     text-align: center;
     padding: 16px;
     box-sizing: border-box;

--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -959,7 +959,7 @@ button.link {
     margin: 0;
 }
 
-.UnknownRoomView {
+.UnknownRoomView_body {
     align-items: center;
     justify-content: center;
     text-align: center;

--- a/src/platform/web/ui/session/CreateRoomView.js
+++ b/src/platform/web/ui/session/CreateRoomView.js
@@ -21,8 +21,8 @@ import {StaticView} from "../general/StaticView";
 
 export class CreateRoomView extends TemplateView {
     render(t, vm) {
-        return t.main({className: "middle"}, 
-            t.div({className: "CreateRoomView centered-column"}, [
+        return t.main({className: "CreateRoomView middle"},
+            t.div({className: "CreateRoomView_body centered-column"}, [
                 t.h2("Create room"),
                 //t.div({className: "RoomView_error"}, vm => vm.error),
                 t.form({className: "CreateRoomView_detailsForm form", onChange: evt => this.onFormChange(evt), onSubmit: evt => this.onSubmit(evt)}, [

--- a/src/platform/web/ui/session/CreateRoomView.js
+++ b/src/platform/web/ui/session/CreateRoomView.js
@@ -24,9 +24,9 @@ export class CreateRoomView extends TemplateView {
         return t.main({className: "CreateRoomView middle"}, [
             t.div({className: "CreateRoomView_header middle-header"}, [
                 t.a({className: "button-utility close-middle", href: vm.closeUrl, title: vm.i18n`Cancel room creation`}),
+                t.h2("Create room"),
             ]),
             t.div({className: "CreateRoomView_body centered-column"}, [
-                t.h2("Create room"),
                 //t.div({className: "RoomView_error"}, vm => vm.error),
                 t.form({className: "CreateRoomView_detailsForm form", onChange: evt => this.onFormChange(evt), onSubmit: evt => this.onSubmit(evt)}, [
                     t.div({className: "vertical-layout"}, [

--- a/src/platform/web/ui/session/CreateRoomView.js
+++ b/src/platform/web/ui/session/CreateRoomView.js
@@ -21,7 +21,10 @@ import {StaticView} from "../general/StaticView";
 
 export class CreateRoomView extends TemplateView {
     render(t, vm) {
-        return t.main({className: "CreateRoomView middle"},
+        return t.main({className: "CreateRoomView middle"}, [
+            t.div({className: "CreateRoomView_header middle-header"}, [
+                t.a({className: "button-utility close-middle", href: vm.closeUrl, title: vm.i18n`Cancel room creation`}),
+            ]),
             t.div({className: "CreateRoomView_body centered-column"}, [
                 t.h2("Create room"),
                 //t.div({className: "RoomView_error"}, vm => vm.error),
@@ -96,7 +99,7 @@ export class CreateRoomView extends TemplateView {
                     ]),
                 ])
             ])
-        );
+        ]);
     }
 
     onFormChange(evt) {

--- a/src/platform/web/ui/session/JoinRoomView.ts
+++ b/src/platform/web/ui/session/JoinRoomView.ts
@@ -27,8 +27,8 @@ export class JoinRoomView extends TemplateView<JoinRoomViewModel> {
             placeholder: vm.i18n`Enter a room id or alias`,
             disabled: vm => vm.joinInProgress,
         });
-        return t.main({className: "middle"}, 
-            t.div({className: "JoinRoomView centered-column"}, [
+        return t.main({className: "JoinRoomView middle"},
+            t.div({className: "JoinRoomView_body centered-column"}, [
                 t.h2("Join room"),
                 t.form({className: "JoinRoomView_detailsForm form", onSubmit: evt => this.onSubmit(evt,  input.value)}, [
                     t.div({className: "vertical-layout"}, [
@@ -60,4 +60,3 @@ export class JoinRoomView extends TemplateView<JoinRoomViewModel> {
         this.value.join(id);
     }
 }
-

--- a/src/platform/web/ui/session/JoinRoomView.ts
+++ b/src/platform/web/ui/session/JoinRoomView.ts
@@ -30,9 +30,9 @@ export class JoinRoomView extends TemplateView<JoinRoomViewModel> {
         return t.main({className: "JoinRoomView middle"}, [
             t.div({className: "JoinRoomView_header middle-header"}, [
                 t.a({className: "button-utility close-middle", href: vm.closeUrl, title: vm.i18n`Cancel room join`}),
+                t.h2("Join room"),
             ]),
             t.div({className: "JoinRoomView_body centered-column"}, [
-                t.h2("Join room"),
                 t.form({className: "JoinRoomView_detailsForm form", onSubmit: evt => this.onSubmit(evt,  input.value)}, [
                     t.div({className: "vertical-layout"}, [
                         t.div({className: "stretch form-row text"}, [

--- a/src/platform/web/ui/session/JoinRoomView.ts
+++ b/src/platform/web/ui/session/JoinRoomView.ts
@@ -27,7 +27,10 @@ export class JoinRoomView extends TemplateView<JoinRoomViewModel> {
             placeholder: vm.i18n`Enter a room id or alias`,
             disabled: vm => vm.joinInProgress,
         });
-        return t.main({className: "JoinRoomView middle"},
+        return t.main({className: "JoinRoomView middle"}, [
+            t.div({className: "JoinRoomView_header middle-header"}, [
+                t.a({className: "button-utility close-middle", href: vm.closeUrl, title: vm.i18n`Cancel room join`}),
+            ]),
             t.div({className: "JoinRoomView_body centered-column"}, [
                 t.h2("Join room"),
                 t.form({className: "JoinRoomView_detailsForm form", onSubmit: evt => this.onSubmit(evt,  input.value)}, [
@@ -52,7 +55,7 @@ export class JoinRoomView extends TemplateView<JoinRoomViewModel> {
                     })
                 ])
             ])
-        );
+        ]);
     }
 
     onSubmit(evt, id) {

--- a/src/platform/web/ui/session/room/UnknownRoomView.js
+++ b/src/platform/web/ui/session/room/UnknownRoomView.js
@@ -24,17 +24,19 @@ export class UnknownRoomView extends TemplateView {
                 t.h2("Join room"),
             ]),
             t.div({className: "UnknownRoomView_body centered-column"}, [
-                t.h2([
-                    vm.i18n`You are currently not in ${vm.roomIdOrAlias}.`,
-                    t.br(),
-                    vm.i18n`Want to join it?`
-                ]),
-                t.button({
-                    className: "button-action primary",
-                    onClick: () => vm.join(),
-                    disabled: vm => vm.busy,
-                }, vm.i18n`Join room`),
-                t.if(vm => vm.error, t => t.p({className: "error"}, vm.error))
+                t.div({className: "UnknownRoomView_container"}, [
+                    t.h2([
+                        vm.i18n`You are currently not in ${vm.roomIdOrAlias}.`,
+                        t.br(),
+                        vm.i18n`Want to join it?`
+                    ]),
+                    t.button({
+                        className: "button-action primary",
+                        onClick: () => vm.join(),
+                        disabled: vm => vm.busy,
+                    }, vm.i18n`Join room`),
+                    t.if(vm => vm.error, t => t.p({className: "error"}, vm.error))
+                ])
             ])
         ]);
     }

--- a/src/platform/web/ui/session/room/UnknownRoomView.js
+++ b/src/platform/web/ui/session/room/UnknownRoomView.js
@@ -19,6 +19,10 @@ import {TemplateView} from "../../general/TemplateView";
 export class UnknownRoomView extends TemplateView {
     render(t, vm) {
         return t.main({className: "UnknownRoomView middle"}, [
+            t.div({className: "UnknownRoomView_header middle-header"}, [
+                t.a({className: "button-utility close-middle", href: vm.closeUrl, title: vm.i18n`Cancel room join`}),
+                t.h2("Join room"),
+            ]),
             t.div({className: "UnknownRoomView_body centered-column"}, [
                 t.h2([
                     vm.i18n`You are currently not in ${vm.roomIdOrAlias}.`,

--- a/src/platform/web/ui/session/room/UnknownRoomView.js
+++ b/src/platform/web/ui/session/room/UnknownRoomView.js
@@ -18,18 +18,20 @@ import {TemplateView} from "../../general/TemplateView";
 
 export class UnknownRoomView extends TemplateView {
     render(t, vm) {
-        return t.main({className: "UnknownRoomView middle"}, t.div([
-            t.h2([
-                vm.i18n`You are currently not in ${vm.roomIdOrAlias}.`,
-                t.br(),
-                vm.i18n`Want to join it?`
-            ]),
-            t.button({
-                className: "button-action primary",
-                onClick: () => vm.join(),
-                disabled: vm => vm.busy,
-            }, vm.i18n`Join room`),
-            t.if(vm => vm.error, t => t.p({className: "error"}, vm.error))
-        ]));
+        return t.main({className: "UnknownRoomView middle"}, [
+            t.div({className: "UnknownRoomView_body centered-column"}, [
+                t.h2([
+                    vm.i18n`You are currently not in ${vm.roomIdOrAlias}.`,
+                    t.br(),
+                    vm.i18n`Want to join it?`
+                ]),
+                t.button({
+                    className: "button-action primary",
+                    onClick: () => vm.join(),
+                    disabled: vm => vm.busy,
+                }, vm.i18n`Join room`),
+                t.if(vm => vm.error, t => t.p({className: "error"}, vm.error))
+            ])
+        ]);
     }
 }


### PR DESCRIPTION
Fixes #903 #904 #936

When hydrogen is in "single-column" mode (i.e. small screen), entering certain views related to creating or joining a room makes it impossible for the user to exit that view.

The user could use the browser back button of course, but in situations where that is not possible (e.g. when hydrogen is being rendered in an `iframe`), the user will be locked in that screen. The only solution out of it is to delete local storage.

For consistency with other views, I think it would make sense to allow the user to go back using the same mechanism they use in other views, i.e. the _back_ button on the view header.

Signed-off-by: Paulo Pinto <paulo.pinto@automattic.com>

## Screen captures

| Before | After |
|--------|------|
| <img width="567" alt="Screenshot 2022-12-13 at 17 44 02" src="https://user-images.githubusercontent.com/550401/207406954-71705928-aca7-474e-8458-5f1fa4901df9.png"> | <img width="567" alt="Screenshot 2022-12-13 at 17 44 30" src="https://user-images.githubusercontent.com/550401/207407076-d7915e4a-4d05-4552-b514-0107d7c4b351.png"> |
| <img width="567" alt="Screenshot 2022-12-13 at 17 44 10" src="https://user-images.githubusercontent.com/550401/207407148-1e8a113a-01e9-4f1b-9766-da0ada83005c.png"> | <img width="567" alt="Screenshot 2022-12-13 at 17 44 38" src="https://user-images.githubusercontent.com/550401/207407302-67c2ffe8-b287-443e-bf82-4c46b36c8623.png"> |
| <img width="748" alt="Screenshot 2023-01-09 at 16 01 47" src="https://user-images.githubusercontent.com/550401/211352681-e714c293-12b3-4e38-b45c-f2d21c8077de.png"> | <img width="748" alt="after" src="https://user-images.githubusercontent.com/550401/211352751-48da0009-5ccc-49a2-ac9b-978b9a99ac5d.png"> |


