### PR TITLE
fix normalizing of homeserver

### DIFF
--- a/src/matrix/well-known.js
+++ b/src/matrix/well-known.js
@@ -15,10 +15,13 @@ limitations under the License.
 */
 
 function normalizeHomeserver(homeserver) {
+    if ( !homeserver.startsWith('http://') && !homeserver.startsWith('https://') ) {
+        homeserver = 'https://' + homeserver;
+    }
     try {
         return new URL(homeserver).origin;
     } catch (err) {
-        return new URL(`https://${homeserver}`).origin;
+        return '';
     }
 }
 

--- a/src/matrix/well-known.js
+++ b/src/matrix/well-known.js
@@ -54,3 +54,17 @@ export async function lookupHomeserver(homeserver, request) {
     }
     return homeserver;
 }
+
+export function tests() {
+    return {
+        "normalizing homeserver": assert => {
+            assert.equal(normalizeHomeserver('matrix.org'), 'https://matrix.org');
+            assert.equal(normalizeHomeserver('matrix.org:8008'), 'https://matrix.org:8008');
+            assert.equal(normalizeHomeserver('https://matrix.org'), 'https://matrix.org');
+            assert.equal(normalizeHomeserver('https://matrix.org:8008'), 'https://matrix.org:8008');
+            assert.equal(normalizeHomeserver('localhost'), 'https://localhost');
+            assert.equal(normalizeHomeserver('http:// invalid'), '');
+            assert.equal(normalizeHomeserver('inv alid'), '');
+        },
+    }
+}


### PR DESCRIPTION
PR fixes the normalizing approach towards homeserver.

Before this PR, function wasn't able to normalize `synapse.dev:8008` homeserver correctly.

Here is the output prior to this PR:
```
"synapse.dev" -> "https://synapse.dev"
"synapse.dev:8008" -> "null"
"https://matrix.org" -> "https://matrix.org"
"https://matrix.org:8080" -> "https://matrix.org:8080"
"http:// invalid" -> "https://http"
```

With the changes in PR, the output is as follows:
```
"synapse.dev" -> "https://synapse.dev"
"synapse.dev:8008" -> "https://synapse.dev:8008"
"https://matrix.org" -> "https://matrix.org"
"https://matrix.org:8080" -> "https://matrix.org:8080"
"http:// invalid" -> ""
```

Signed-off-by: Ashish Kumar <ashfame@users.noreply.github.com>