### PR TITLE
Use target platform (rather than build platform) for multi-platform container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN yarn build
 RUN mv -f target/config.json /config.json.bundled \
   && ln -sf /tmp/config.json target/config.json
 
-FROM --platform=${BUILDPLATFORM} docker.io/nginxinc/nginx-unprivileged:alpine
+FROM --platform=${TARGETPLATFORM} docker.io/nginxinc/nginx-unprivileged:alpine
 
 # Copy the dynamic config script
 COPY ./docker/dynamic-config.sh /docker-entrypoint.d/99-dynamic-config.sh


### PR DESCRIPTION
This patch fixes b993bc09556935e1c0b9bc685bf9da4b1115a331, which as demonstrated in [my review](https://github.com/vector-im/hydrogen-web/pull/996/files/b993bc09556935e1c0b9bc685bf9da4b1115a331#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557) does the wrong thing when being run on arm64 (or any non-amd64 system after having been build on amd64).

I've tested this on my [own fork](https://github.com/mattcen/hydrogen-web/pkgs/container/hydrogen-web) and confirmed that the result correctly starts up Hydrogen on both arm64 and amd64. 