### PR TITLE
expose method on BlobHandle to create a handle without mimetype filtering

### DIFF
--- a/src/platform/web/Platform.js
+++ b/src/platform/web/Platform.js
@@ -300,7 +300,8 @@ export class Platform {
                 const file = input.files[0];
                 this._container.removeChild(input);
                 if (file) {
-                    resolve({name: file.name, blob: BlobHandle.fromBlob(file)});
+                    // ok to not filter mimetypes as these are local files
+                    resolve({name: file.name, blob: BlobHandle.fromBlobUnsafe(file)});
                 } else {
                     resolve();
                 }

--- a/src/platform/web/dom/BlobHandle.js
+++ b/src/platform/web/dom/BlobHandle.js
@@ -76,19 +76,12 @@ const DEFAULT_MIMETYPE = 'application/octet-stream';
 export class BlobHandle {
     /** 
      * @internal
-     * Don't use the constructor directly, instead use fromBuffer, fromBlob or fromBufferUnsafe
+     * Don't use the constructor directly, instead use fromBuffer or fromBlobUnsafe
      * */
     constructor(blob, buffer = null) {
         this._blob = blob;
         this._buffer = buffer;
         this._url = null;
-    }
-
-    /** Does not filter out mimetypes that could execute embedded javascript.
-     * It's up to the callee of this method to ensure that the blob won't be
-     * rendered by the browser in a way that could allow cross-signing scripting. */
-    static fromBufferUnsafe(buffer, mimetype) {
-        return new BlobHandle(new Blob([buffer], {type: mimetype}), buffer);
     }
 
     static fromBuffer(buffer, mimetype) {
@@ -99,8 +92,10 @@ export class BlobHandle {
         return new BlobHandle(new Blob([buffer], {type: mimetype}), buffer);
     }
 
-    static fromBlob(blob) {
-        // ok to not filter mimetypes as these are local files
+    /** Does not filter out mimetypes that could execute embedded javascript.
+     * It's up to the callee of this method to ensure that the blob won't be
+     * rendered by the browser in a way that could allow cross-signing scripting. */
+    static fromBlobUnsafe(blob) {
         return new BlobHandle(blob);
     }
 

--- a/src/platform/web/dom/ImageHandle.js
+++ b/src/platform/web/dom/ImageHandle.js
@@ -64,7 +64,8 @@ export class ImageHandle {
         } else {
             throw new Error("canvas can't be turned into blob");
         }
-        const blob = BlobHandle.fromBlob(nativeBlob);
+        // unsafe is ok because it's a jpeg or png image
+        const blob = BlobHandle.fromBlobUnsafe(nativeBlob);
         return new ImageHandle(blob, scaledWidth, scaledHeight, null);
     }
 


### PR DESCRIPTION
from a blob, rather than a buffer as previously assumed