### PR TITLE
Accommodate long dates in sticky date headers

### DIFF
--- a/src/platform/web/ui/css/themes/element/timeline.css
+++ b/src/platform/web/ui/css/themes/element/timeline.css
@@ -433,7 +433,7 @@ only loads when the top comes into view*/
 .DateHeader time {
     margin: 0 auto;
     padding: 12px 4px;
-    width: 250px;
+    max-width: 350px;
     padding: 12px;
     display: block;
     color: var(--light-text-color);


### PR DESCRIPTION
Accommodate long dates in sticky date headers

Example: `Wednesday, November 16, 2022`

Before | After
--- | ---
![](https://user-images.githubusercontent.com/558581/234705827-4c3096cb-c5ce-4747-b03a-7c68664b372d.png) | ![](https://user-images.githubusercontent.com/558581/234705823-b1783ef1-03ec-4718-ae31-68f776cb08aa.png)


*Split out from https://github.com/vector-im/hydrogen-web/pull/653*

## Dev notes

Sticky date headers originally introduced in https://github.com/vector-im/hydrogen-web/pull/938
