### PR TITLE
Fix large log files generated when calls are used

### DIFF
--- a/src/logging/LogItem.ts
+++ b/src/logging/LogItem.ts
@@ -28,6 +28,7 @@ export class LogItem implements ILogItem {
     protected _logger: Logger;
     private _filterCreator?: FilterCreator;
     private _children?: Array<LogItem>;
+    private _discard: boolean = false;
 
     constructor(labelOrValues: LabelOrValues, logLevel: LogLevel, logger: Logger, filterCreator?: FilterCreator) {
         this._logger = logger;
@@ -36,6 +37,13 @@ export class LogItem implements ILogItem {
         this._values = typeof labelOrValues === "string" ? {l: labelOrValues} : labelOrValues;
         this.logLevel = logLevel;
         this._filterCreator = filterCreator;
+    }
+
+    /**
+     * Prevents this log item from being present in the exported output.
+     */
+    discard(): void {
+        this._discard = true;
     }
 
     /** start a new root log item and run it detached mode, see Logger.runDetached */
@@ -119,6 +127,9 @@ export class LogItem implements ILogItem {
     }
 
     serialize(filter: LogFilter, parentStartTime: number | undefined, forced: boolean): ISerializedItem | undefined {
+        if (this._discard) {
+            return;
+        }
         if (this._filterCreator) {
             try {
                 filter = this._filterCreator(new LogFilter(filter), this);

--- a/src/logging/NullLogger.ts
+++ b/src/logging/NullLogger.ts
@@ -74,6 +74,10 @@ export class NullLogItem implements ILogItem {
         this.logger = logger;
     }
 
+    discard(): void {
+        // noop
+    }
+
     wrap<T>(_: LabelOrValues, callback: LogCallback<T>): T {
         return this.run(callback);
     }

--- a/src/logging/types.ts
+++ b/src/logging/types.ts
@@ -55,6 +55,7 @@ export interface ILogItem {
     finish(): void;
     forceFinish(): void;
     child(labelOrValues: LabelOrValues, logLevel?: LogLevel, filterCreator?: FilterCreator): ILogItem;
+    discard(): void;
 }
 /*
 extend both ILogger and ILogItem from this interface, but need to rename ILogger.run => wrap then. Or both to `span`?

--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -78,6 +78,9 @@ export class Session {
         this._roomsBeingCreated = new ObservableMap();
         this._user = new User(sessionInfo.userId);
         this._roomStateHandler = new RoomStateHandlerSet();
+        if (features.calls) {
+            this._setupCallHandler();
+        }
         this._deviceMessageHandler = new DeviceMessageHandler({storage, callHandler: this._callHandler});
         this._olm = olm;
         this._olmUtil = null;
@@ -106,10 +109,6 @@ export class Session {
         this._createRoomEncryption = this._createRoomEncryption.bind(this);
         this._forgetArchivedRoom = this._forgetArchivedRoom.bind(this);
         this.needsKeyBackup = new ObservableValue(false);
-
-        if (features.calls) {
-            this._setupCallHandler();
-        }
     }
 
     get fingerprintKey() {

--- a/src/matrix/calls/group/GroupCall.ts
+++ b/src/matrix/calls/group/GroupCall.ts
@@ -424,6 +424,11 @@ export class GroupCall extends EventEmitter<{change: never}> {
                                     member.dispose();
                                     this._members.remove(memberKey);
                                     log.set("removed", true);
+                                } else {
+                                    // We don't want to pollute the logs with all the expired members.
+                                    // This can be an issue for long lived calls that have had a large number
+                                    // of users join and leave at some point in time.
+                                    log.discard();
                                 }
                                 return;
                             }


### PR DESCRIPTION
- Adds a `discard()` method to `LogItem` that will prevent it from appearing in the persisted logs.
- Fix an issue where signalling messages for calls were not being processed because `CallHandler` was used before it was initialized.