### PR TITLE
Fix member dispose mutating global member options

### DIFF
--- a/src/matrix/calls/group/Member.ts
+++ b/src/matrix/calls/group/Member.ts
@@ -33,6 +33,8 @@ import type {ILogItem} from "../../../logging/types";
 import type {BaseObservableValue} from "../../../observable/value";
 import type {Clock, Timeout} from "../../../platform/web/dom/Clock";
 
+export type MemberUpdateEmitter = (participant: Member, params?: any) => void;
+
 export type Options = Omit<PeerCallOptions, "emitUpdate" | "sendSignallingMessage" | "turnServer"> & {
     confId: string,
     ownUserId: string,
@@ -41,7 +43,7 @@ export type Options = Omit<PeerCallOptions, "emitUpdate" | "sendSignallingMessag
     sessionId: string,
     hsApi: HomeServerApi,
     encryptDeviceMessage: (userId: string, deviceId: string, message: SignallingMessage<MGroupCallBase>, log: ILogItem) => Promise<EncryptedMessage | undefined>,
-    emitUpdate: (participant: Member, params?: any) => void,
+    emitUpdate: MemberUpdateEmitter,
     clock: Clock
 }
 
@@ -105,8 +107,9 @@ class MemberConnection {
 export class Member {
     private connection?: MemberConnection;
     private expireTimeout?: Timeout;
+    private emitMemberUpdate: MemberUpdateEmitter;
     private errorBoundary = new ErrorBoundary(err => {
-        this.options.emitUpdate(this, "error");
+        this.emitMemberUpdate(this, "error");
         if (this.connection) {
             // in case the error happens in code that does not log,
             // log it here to make sure it isn't swallowed
@@ -120,6 +123,7 @@ export class Member {
         private options: Options,
         updateMemberLog: ILogItem
     ) {
+        this.emitMemberUpdate = this.options.emitUpdate;
         this._renewExpireTimeout(updateMemberLog);
     }
 
@@ -144,7 +148,7 @@ export class Member {
         // add 10ms to make sure isExpired returns true
         this.expireTimeout = this.options.clock.createTimeout(expiresFromNow + 10);
         this.expireTimeout.elapsed().then(
-            () => { this.options.emitUpdate(this, "isExpired"); },
+            () => { this.emitMemberUpdate(this, "isExpired"); },
             (err) => { /* ignore abort error */ },
         );
     }
@@ -285,7 +289,7 @@ export class Member {
     updateRoomMember(roomMember: RoomMember) {
         this.member = roomMember;
         // TODO: this emits an update during the writeSync phase, which we usually try to avoid
-        this.options.emitUpdate(this);
+        this.emitMemberUpdate(this);
     }
 
     /** @internal */
@@ -317,7 +321,7 @@ export class Member {
                 });
             }
         }
-        this.options.emitUpdate(this, params);
+        this.emitMemberUpdate(this, params);
     }
 
     /** @internal */
@@ -466,8 +470,8 @@ export class Member {
         this.connection = undefined;
         this.expireTimeout?.dispose();
         this.expireTimeout = undefined;
-        // ensure the emitUpdate callback can't be called anymore
-        this.options.emitUpdate = () => {};
+        // ensure the emitMemberUpdate callback can't be called anymore
+        this.emitMemberUpdate = () => {};
     }
 }
 


### PR DESCRIPTION
All the call members share `options` as single object and when one of the member get disposed it mutate the `emitUpdate` option from that global options object. 

After this happening `this._members` observable in `GroupCall` stop getting update about changes happening in all `Member`.