### PR TITLE
Make sure dependencies are available for any consuming project that locally links the SDK

### DIFF
--- a/scripts/sdk/build.sh
+++ b/scripts/sdk/build.sh
@@ -12,6 +12,11 @@ yarn run vite build -c vite.sdk-assets-config.js
 yarn run vite build -c vite.sdk-lib-config.js
 yarn tsc -p tsconfig-declaration.json
 ./scripts/sdk/create-manifest.js ./target/package.json
+pushd target/
+# Make sure the dependencies are available for any consuming project that uses
+# `npm link hydrogen-view-sdk`
+yarn install --no-lockfile
+popd
 mkdir target/paths
 # this doesn't work, the ?url imports need to be in the consuming project, so disable for now
 # ./scripts/sdk/transform-paths.js ./src/platform/web/sdk/paths/vite.js ./target/paths/vite.js


### PR DESCRIPTION
Make sure dependencies are available for any consuming project that locally links the SDK

Unfortunately, if you `npm link hydrogen-view-sdk` in another project, it won't install any of the child dependencies of `hydrogen-view-sdk` on it's own. And will actually remove any child dependencies if you previously had `hydrogen-view-sdk` installed from npm and then linked the project.

### Why should we do this?

I was seeing this problem with the [Matrix Public Archive](https://github.com/matrix-org/matrix-public-archive) where when locally linking via `npm link hydrogen-view-sdk`, all of the child dependencies like `another-json` weren't being found when Vite was bundling things because `npm` was removing those dependencies when linking and Vite doesn't resolve from `../hydrogen-web/node_modules`

This definitely seems like the responsibility of npm to handle but it seems like they're not interested in fixing this. Essentially a bug in npm in my opinion.

 - https://github.com/npm/cli/issues/2339
 - https://stackoverflow.com/questions/66283916/npm-link-removes-child-dependencies
 
I tried the workaround mentioned in https://github.com/npm/cli/issues/2339#issuecomment-1111228605 which is to use `npm install --install-links ../hydrogen-web/target` but it doesn't create a symlink (whereas `npm install ../hydrogen-web/target` creates a symlink) and it wrecks the monorepo [`file:./share` dependency](https://github.com/matrix-org/matrix-public-archive/blob/ff4c948518714ce20d9e354307c8b8b91100d852/package.json#L56) that we also have. (using `npm@9.5.1` which comes with Node.js v18.16.0)

All this to say, it's probably easier for people to avoid all this pain and not have to think about any of this if we just install `node_modules/` for them.