### PR TITLE
Make it possible to disable OTK upload

### DIFF
--- a/src/matrix/Session.js
+++ b/src/matrix/Session.js
@@ -417,8 +417,10 @@ export class Session {
                 log.set("keys", this._e2eeAccount.identityKeys);
                 await this._setupEncryption();
             }
-            await this._e2eeAccount.generateOTKsIfNeeded(this._storage, log);
-            await log.wrap("uploadKeys", log => this._e2eeAccount.uploadKeys(this._storage, false, log));
+            if (!this._sessionInfo.isReadOnly) {
+                await this._e2eeAccount.generateOTKsIfNeeded(this._storage, log);
+                await log.wrap("uploadKeys", log => this._e2eeAccount.uploadKeys(this._storage, false, log));
+            }
             await this._createCrossSigning();
         }
     }
@@ -828,7 +830,7 @@ export class Session {
         // to-device messages, to help us avoid throwing away one-time-keys that we
         // are about to receive messages for
         // (https://github.com/vector-im/riot-web/issues/2782).
-        if (this._e2eeAccount && !isCatchupSync) {
+        if (this._e2eeAccount && !isCatchupSync && !this._sessionInfo.isReadOnly) {
             const needsToUploadOTKs = await this._e2eeAccount.generateOTKsIfNeeded(this._storage, log);
             if (needsToUploadOTKs) {
                 await log.wrap("uploadKeys", log => this._e2eeAccount.uploadKeys(this._storage, false, log));

--- a/src/matrix/sessioninfo/localstorage/SessionInfoStorage.ts
+++ b/src/matrix/sessioninfo/localstorage/SessionInfoStorage.ts
@@ -22,6 +22,15 @@ interface ISessionInfo {
     homeServer: string; // deprecate this over time
     accessToken: string;
     lastUsed: number;
+    /**
+     * If true, then this session will not be used for sending
+     * encrypted messages.
+     * OTK uploads will be disabled when this is true.
+     * 
+     * Encrypted messages can still be decrypted and key backups
+     * can also be restored.
+     */
+    isReadOnly: boolean;
 }
 
 // todo: this should probably be in platform/types?


### PR DESCRIPTION
This PR adds an optional argument to `startWithAuthData` - `isReadOnly` which when set to true will stop Hydrogen from uploading OTKs. This is useful if you want to mount Hydrogen to only see messages and don't intend to send any encrypted messages.