### PR TITLE
Changes for new sdk version 0.1.8

### DIFF
--- a/doc/SDK-CHANGELOG.md
+++ b/doc/SDK-CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.8] - 2023-11-08
+
+### Changed
+
+- Pass `sendReadReceipt: false` to RoomViewModel options to disable sending read receipts, see https://github.com/vector-im/hydrogen-web/pull/1150
+
+### Fixed
+
+- Switch over to olm from npm registry, fixes https://github.com/vector-im/hydrogen-web/issues/1146
+
 ## [v0.1.7] - 2023-10-08
 
 ### Added

--- a/scripts/sdk/base-manifest.json
+++ b/scripts/sdk/base-manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "hydrogen-view-sdk",
     "description": "Embeddable matrix client library, including view components",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "main": "./lib-build/hydrogen.cjs.js",
     "exports": {
         ".": {


### PR DESCRIPTION
### Changed

- Pass `sendReadReceipt: false` to RoomViewModel options to disable sending read receipts, see https://github.com/vector-im/hydrogen-web/pull/1150

### Fixed

- Switch over to olm from npm registry, fixes https://github.com/vector-im/hydrogen-web/issues/1146