### PR TITLE
uploadRoomKeysToBackup: Use V3 route

### DIFF
--- a/src/matrix/net/HomeServerApi.ts
+++ b/src/matrix/net/HomeServerApi.ts
@@ -251,7 +251,8 @@ export class HomeServerApi {
         return this._get(`/room_keys/keys/${encodeURIComponent(roomId)}/${encodeURIComponent(sessionId)}`, {version}, undefined, options);
     }
 
-    uploadRoomKeysToBackup(version: string, payload: Record<string, any>, options?: BaseRequestOptions): IHomeServerRequest {
+    uploadRoomKeysToBackup(version: string, payload: Record<string, any>, options: BaseRequestOptions = {}): IHomeServerRequest {
+        options.prefix = CS_V3_PREFIX;
         return this._put(`/room_keys/keys`, {version}, payload, options);
     }
 


### PR DESCRIPTION
Fixes https://github.com/element-hq/hydrogen-web/issues/741

"Tested" locally by rewriting `r0` to `v3` in reverse proxy (Caddy) and seeing `All keys are backed up.` instead of repeated failing PUT requests towards Conduit (home server)

```
matrix.example.com {
    # this will make Hydrogen and Conduit happy together,
    # but it shouldn't be the responsibility of the reverse proxy:
    rewrite /_matrix/client/r0/room_keys/keys /_matrix/client/v3/room_keys/keys?{query}

    reverse_proxy /_matrix/* localhost:8448
}
```