### PR TITLE
Fix authenticated media breaking in certain SDK scenarios

### DIFF
--- a/src/matrix/Client.js
+++ b/src/matrix/Client.js
@@ -289,6 +289,10 @@ export class Client {
             platform: this._platform,
             serverVersions: lastVersionsResponse.versions,
         });
+
+        // Let the serviceWorkerHandler know of this access-token
+        this._platform.updateService.setAccessToken(sessionInfo.accessToken);
+
         this._session = new Session({
             storage: this._storage,
             sessionInfo: filteredSessionInfo,
@@ -378,6 +382,7 @@ export class Client {
             throw Error("No session loaded, cannot update access token");
         }
         this._session.updateAccessToken(token);
+        await this._platform.updateService.setAccessToken(token);
         await this._platform.sessionInfoStorage.updateAccessToken(this._sessionId, token);
     }
 

--- a/src/platform/web/dom/ServiceWorkerHandler.js
+++ b/src/platform/web/dom/ServiceWorkerHandler.js
@@ -28,10 +28,19 @@ export class ServiceWorkerHandler {
         this._currentController = null;
         this._sessionInfoStorage = sessionInfoStorage;
         this.haltRequests = false;
+        this._accessToken = null;
     }
 
     setNavigation(navigation) {
         this._navigation = navigation;
+    }
+
+    /**
+     * Set the access-token to be used within the service worker.
+     * @param token An access-token
+     */
+    setAccessToken(token) {
+        this._accessToken = token;
     }
 
     registerAndStart(path) {
@@ -88,22 +97,11 @@ export class ServiceWorkerHandler {
         } else if (data.type === "openRoom") {
             this._navigation.push("room", data.payload.roomId);
         } else if (data.type === "getAccessToken") {
-            const token = await this._getLatestAccessToken();
-            event.source.postMessage({ replyTo: data.id, payload: token });
+            event.source.postMessage({
+                replyTo: data.id,
+                payload: this._accessToken,
+            });
         }
-    }
-
-    /**
-     * Fetch access-token from the storage
-     * @returns access token as string
-     */
-    async _getLatestAccessToken() {
-        const currentSessionId = this._navigation?.path.get("session")?.value;
-        if (!currentSessionId) return null;
-        const { accessToken } = await this._sessionInfoStorage.get(
-            currentSessionId
-        );
-        return accessToken;
     }
 
     _closeSessionIfNeeded(sessionId) {

--- a/src/platform/web/sw.js
+++ b/src/platform/web/sw.js
@@ -132,6 +132,11 @@ async function handleRequest({ request, clientId }) {
                 "getAccessToken",
                 {}
             );
+            if (!accessToken) {
+                throw new Error(
+                    "Token returned from getAccessToken message in sw.js is null"
+                );
+            }
             headers.set("authorization", `Bearer ${accessToken}`);
             request = new Request(request, {
                 mode: "cors",


### PR DESCRIPTION
`ServiceWorkerHandler` supplies the access-token to the service worker when needed. We needed the session-id to do this. We took the session-id from `navigation` which is a bad idea since `navigation` segments may not exist when using  hydrogen as an SDK.