### PR TITLE
Render audio messages and stickers

### DIFF
--- a/src/domain/session/room/timeline/tiles/index.ts
+++ b/src/domain/session/room/timeline/tiles/index.ts
@@ -87,6 +87,9 @@ export function tileClassForEntry(entry: TimelineEntry, options: Options): TileC
                         return undefined;
                 }
             }
+            case "m.sticker":
+                // This is an event type and not a message type.
+                return ImageTile;
             case "m.room.name":
                 return RoomNameTile;
             case "m.room.member":

--- a/src/domain/session/room/timeline/tiles/index.ts
+++ b/src/domain/session/room/timeline/tiles/index.ts
@@ -71,6 +71,7 @@ export function tileClassForEntry(entry: TimelineEntry, options: Options): TileC
                     case "m.video":
                         return VideoTile;
                     case "m.file":
+                    case "m.audio":
                         return FileTile;
                     case "m.location":
                         return LocationTile;


### PR DESCRIPTION
This renders audio messages (msgtype m.audio) and stickers (event m.sticker).

Audio messages are rendered as files that can be downloaded and listened to. Adding an inline player is currently above my skills/time/energy but being able to download audio messages is way better than not showing them at all.

Stickers are rendered as images.

Fixes #1187.
Fixes https://github.com/hydrogen-sailfishos/harbour-hydrogen/issues/48 .