### PR TITLE
Improve legibility of quick reaction emojis when using monochrome fonts

### DIFF
--- a/src/platform/web/ui/css/themes/element/theme.css
+++ b/src/platform/web/ui/css/themes/element/theme.css
@@ -904,6 +904,7 @@ button.link {
 .menu .quick-reactions button {
     padding: 2px 4px;
     text-align: center;
+    color: var(--text-color);
 }
 
 .InviteView_body {


### PR DESCRIPTION
This fixes an issue in an app based on Hydrogen (https://github.com/hydrogen-sailfishos/harbour-hydrogen). where emojis are hardly legible when/because they are rendered in a monochrome font.

Before:
![color-before](https://github.com/user-attachments/assets/8ae54fec-d8c6-468f-b8d4-bf20528c1f1b)

After:
![color-after](https://github.com/user-attachments/assets/9d973e7e-03de-4d76-8c74-be11ccf5bcf2)

Fixes https://github.com/hydrogen-sailfishos/harbour-hydrogen/issues/54.