### PR TITLE
Fix garbled replies to replies due to invalid reply formatting

### DIFF
--- a/src/domain/session/room/timeline/tiles/BaseMessageTile.js
+++ b/src/domain/session/room/timeline/tiles/BaseMessageTile.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2020 Bruno Windels <bruno@windels.cloud>
+Copyright 2024 Mirian Margiani <mixosaurus+ichthyo@pm.me>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -147,7 +148,7 @@ export class BaseMessageTile extends SimpleTile {
     }
 
     createReplyContent(msgtype, body) {
-        return this._entry.createReplyContent(msgtype, body);
+        return this._entry.createReplyContent(msgtype, body, this.permaLink);
     }
 
     redact(reason, log) {

--- a/src/matrix/room/timeline/entries/BaseEventEntry.js
+++ b/src/matrix/room/timeline/entries/BaseEventEntry.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2021 The Matrix.org Foundation C.I.C.
+Copyright 2024 Mirian Margiani <mixosaurus+ichthyo@pm.me>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -185,8 +186,8 @@ export class BaseEventEntry extends BaseEntry {
         return createAnnotation(this.id, key);
     }
 
-    createReplyContent(msgtype, body) {
-        return createReplyContent(this, msgtype, body);
+    createReplyContent(msgtype, body, permaLink) {
+        return createReplyContent(this, msgtype, body, permaLink);
     }
 
     /** takes both remote event id and local txn id into account, see overriding in PendingEventEntry */

--- a/src/matrix/room/timeline/entries/reply.js
+++ b/src/matrix/room/timeline/entries/reply.js
@@ -37,6 +37,41 @@ function fallbackPrefix(msgtype) {
     return msgtype === "m.emote" ? "* " : "";
 }
 
+function _parsePlainBody(plainBody) {
+    // Strip any existing reply fallback and return an array of lines.
+
+    const bodyLines = plainBody.trim().split("\n");
+
+    return bodyLines
+        .map((elem, index, array) => {
+            if (index > 0 && array[index-1][0] !== '>') {
+                // stop stripping the fallback at the first line of non-fallback text
+                return elem;
+            } else if (elem[0] === '>' && elem[1] === ' ') {
+                return null;
+            } else {
+                return elem;
+            }
+        })
+        .filter((elem) => elem !== null)
+        // Join, trim, and split to remove any line breaks that were left between the
+        // fallback and the actual message body. Don't use trim() because that would
+        // also remove any other whitespace at the beginning of the message that the
+        // user added intentionally.
+        .join('\n')
+        .replace(/^\n+|\n+$/g, '')
+        .split('\n')
+}
+
+function _parseFormattedBody(formattedBody) {
+    // Strip any existing reply fallback and return a HTML string again.
+
+    // This is greedy and definitely not the most efficient way to do it.
+    // However, this function is only called when sending a reply (so: not too
+    // often) and it should make sure that all instances of <mx-reply> are gone.
+    return formattedBody.replace(/<mx-reply>[\s\S]*<\/mx-reply>/gi, '');
+}
+
 function _createReplyContent(targetId, msgtype, body, formattedBody) {
     return {
         msgtype,
@@ -48,28 +83,40 @@ function _createReplyContent(targetId, msgtype, body, formattedBody) {
                 "event_id": targetId
             }
         }
+        // TODO include user mentions
     };
 }
 
 export function createReplyContent(entry, msgtype, body, permaLink) {
-    // TODO check for absense of sender / body / msgtype / etc?
+    // NOTE We assume sender, body, and msgtype are never invalid because they
+    //      are required fields.
     const nonTextual = fallbackForNonTextualMessage(entry.content.msgtype);
     const prefix = fallbackPrefix(entry.content.msgtype);
     const sender = entry.sender;
-    const name = entry.displayName || sender;
+    const repliedToId = entry.id;
+    // TODO collect user mentions (sender and any previous mentions)
 
-    const formattedBody = nonTextual || entry.content.formatted_body ||
-        (entry.content.body && htmlEscape(entry.content.body)) || "";
-    const formattedFallback = `<mx-reply><blockquote>In reply to ${prefix}` +
-        `<a href="https://matrix.to/#/${sender}">${name}</a><br />` +
-        `${formattedBody}</blockquote></mx-reply>`;
-
+    // Generate new plain body with plain reply fallback
     const plainBody = nonTextual || entry.content.body || "";
-    const bodyLines = plainBody.split("\n");
+    const bodyLines = _parsePlainBody(plainBody);
     bodyLines[0] = `> ${prefix}<${sender}> ${bodyLines[0]}`
     const plainFallback = bodyLines.join("\n> ");
-
     const newBody = plainFallback + '\n\n' + body;
-    const newFormattedBody = formattedFallback + htmlEscape(body);
+
+    // Generate new formatted body with formatted reply fallback
+    const formattedBody = nonTextual || entry.content.formatted_body ||
+        (entry.content.body && htmlEscape(entry.content.body)) || "";
+    const cleanedFormattedBody = _parseFormattedBody(formattedBody);
+    const formattedFallback =
+        `<mx-reply>` +
+            `<blockquote>` +
+                `<a href="${permaLink}">In reply to</a>` +
+                `${prefix}<a href="https://matrix.to/#/${sender}">${sender}</a>` +
+                `<br />` +
+                `${cleanedFormattedBody}` +
+            `</blockquote>` +
+        `</mx-reply>`;
+    const newFormattedBody = formattedFallback + htmlEscape(body).replaceAll('\n', '<br/>');
+
     return _createReplyContent(entry.id, msgtype, newBody, newFormattedBody);
 }

--- a/src/matrix/room/timeline/entries/reply.js
+++ b/src/matrix/room/timeline/entries/reply.js
@@ -1,5 +1,6 @@
 /*
 Copyright 2021 The Matrix.org Foundation C.I.C.
+Copyright 2024 Mirian Margiani <mixosaurus+ichthyo@pm.me>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -50,7 +51,7 @@ function _createReplyContent(targetId, msgtype, body, formattedBody) {
     };
 }
 
-export function createReplyContent(entry, msgtype, body) {
+export function createReplyContent(entry, msgtype, body, permaLink) {
     // TODO check for absense of sender / body / msgtype / etc?
     const nonTextual = fallbackForNonTextualMessage(entry.content.msgtype);
     const prefix = fallbackPrefix(entry.content.msgtype);


### PR DESCRIPTION
Due to invalid formatting, replies to replies became garbled, causing display issues in some clients. Hydrogen itself managed
to display the replies correctly but other clients and bridges struggled because they were actually using the fallbacks.

The PR fixes the formatting of reply fallbacks (current spec: https://spec.matrix.org/v1.12/client-server-api/#fallbacks-for-rich-replies) and "mentions" the replied-to user when replying to a message as per https://spec.matrix.org/v1.12/client-server-api/#mentioning-the-replied-to-user.

In the examples below, I used a compliant client to send "first message", and to sent "second message" as a reply to "first message". I then sent "Hydrogen message" using Hydrogen as a reply to "second message".

Old, invalid formatting of reply fallbacks:

```json
{
  "content": {
    "body": "> <@user:example.org> > <@user:example.org> first message\n> \n> second message\n\nHydrogen message",
    "format": "org.matrix.custom.html",
    "formatted_body": "<mx-reply><blockquote>In reply to <a href=\"https://matrix.to/#/@user:example.org\">User</a><br /><mx-reply><blockquote><a href=\"https://matrix.to/#/!xxxxxxxxxxxxxxxxxx:example.org/$event\">In reply to</a> <a href=\"https://matrix.to/#/@user:example.org\">@user:example.org</a><br>first message</blockquote></mx-reply>second message</blockquote></mx-reply>Hydrogen message",
    "m.relates_to": {
      "m.in_reply_to": {
        "event_id": "$event"
      }
    },
    "msgtype": "m.text"
  },
  "event_id": "$...",
  "sender": "@user:example.org",
  "type": "m.room.message",
}
```

```xml
<!-- only the formatted_body part: -->
<mx-reply>
    <blockquote>
        In reply to
        <a href=\"https://matrix.to/#/@user:example.org\">
            User
        </a>
        <br />
        <mx-reply>
            <blockquote>
                <a href=\"https://matrix.to/#/!xxxxxxxxxxxxxxxxxx:example.org/$event\">
                    In reply to
                </a>
                <a href=\"https://matrix.to/#/@user:example.org\">
                    @user:example.org
                </a>
                <br>
                first message
            </blockquote>
        </mx-reply>
        second message
    </blockquote>
</mx-reply>
Hydrogen message
```

New, correct formatting of reply fallbacks:

```json
{
  "content": {
    "body": "> <@user:example.org> second message\n\nHydrogen ",
    "format": "org.matrix.custom.html",
    "formatted_body": "<mx-reply><blockquote><a href=\"https://matrix.to/#/!xxxxxxxxxxxxxxxxxx%3Aexample.org/%24event\">In reply to</a><a href=\"https://matrix.to/#/@user:example.org\">@user:example.org</a><br />second message</blockquote></mx-reply>Hydrogen message",
    "m.mentions": {
      "user_ids": [
        "@user:example.org"
      ]
    },
    "m.relates_to": {
      "m.in_reply_to": {
        "event_id": "$event"
      }
    },
    "msgtype": "m.text"
  },
  "event_id": "$...",
  "sender": "@user:example.org",
  "type": "m.room.message",
}
```


```xml
<!-- only the formatted_body part: -->
<mx-reply>
    <blockquote>
        <a href=\"https://matrix.to/#/!xxxxxxxxxxxxxxxxxx%3Aexample.org/%24event\">
            In reply to
        </a>
        <a href=\"https://matrix.to/#/@user:example.org\">
            @user:example.org
        </a>
        <br />
        second message
    </blockquote>
</mx-reply>
Hydrogen message
```

---

Reply fallbacks are actively being removed in the upcoming spec but that doesn't mean that Hydrogen should keep the old bugged code in place.

MSCs for the upcoming spec:
- https://github.com/matrix-org/matrix-spec-proposals/pull/2781
- https://github.com/matrix-org/matrix-spec-proposals/pull/3676
- spec: https://github.com/matrix-org/matrix-spec/pull/1994